### PR TITLE
Temporarily prefix package names with `cardano-` for CHaP publication.

### DIFF
--- a/fs-api/cardano-fs-api.cabal
+++ b/fs-api/cardano-fs-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 
-name:               fs-api
+name:               cardano-fs-api
 version:            0.1.0.0
 synopsis:           API for file systems
 description:        API for file systems.

--- a/fs-sim/cardano-fs-sim.cabal
+++ b/fs-sim/cardano-fs-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 
-name:               fs-sim
+name:               cardano-fs-sim
 version:            0.1.0.0
 synopsis:           Simulated file systems
 description:        Simulated file systems.
@@ -40,7 +40,7 @@ library
                     , base16-bytestring
                     , bytestring  >=0.10  && <0.12
                     , containers  >=0.5   && <0.7
-                    , fs-api
+                    , cardano-fs-api
                     , io-classes ^>=0.3
                     , mtl
                     , nothunks    >=0.1.2 && <0.2
@@ -73,8 +73,8 @@ test-suite fs-sim-test
                     , bifunctors
                     , bytestring
                     , containers
-                    , fs-api
-                    , fs-sim
+                    , cardano-fs-api
+                    , cardano-fs-sim
                     , generics-sop
                     , pretty-show
                     , QuickCheck


### PR DESCRIPTION
To prevent name clashes in the future when we publish `fs-sim` and `fs-api` to Hackage, we prefix the package names with `cardano-`, and they will published to CHaP under that name.