### PR TITLE
Fix `unix-bytestring` version to `>= 0.4.0`

### DIFF
--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -65,7 +65,7 @@ library
     build-depends:    Win32            >= 2.6.1.0
   else
     build-depends:    unix
-                    , unix-bytestring
+                    , unix-bytestring  >= 0.4.0
 
   ghc-options:        -Wall
                       -Wcompat

--- a/fs-api/src-unix/System/IO/FS.hs
+++ b/fs-api/src-unix/System/IO/FS.hs
@@ -21,15 +21,12 @@ import qualified Data.ByteString.Internal as Internal
 import           Data.Int (Int64)
 import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Ptr)
-import qualified System.Posix as Posix
-import           System.Posix (Fd)
-
--- Package 'unix' exports the same module.
-import           "unix-bytestring" System.Posix.IO.ByteString (fdPreadBuf)
-
 import           System.FS.API.Types (AllowExisting (..), FsError,
                      OpenMode (..), SeekMode (..), sameFsError)
 import           System.FS.Handle
+import qualified System.Posix as Posix
+import           System.Posix (Fd)
+import           System.Posix.IO.ByteString.Ext (fdPreadBuf)
 
 type FHandle = HandleOS Fd
 


### PR DESCRIPTION
Builds were suddenly failing because `unix-bytestring-0.4.0` was released, which renames modules to avoid name clashes with the `unix` package.