### PR TITLE
Allow creating absolute `FilePath`s from relative `FsPath`s

### DIFF
--- a/fs-api/src/System/FS/API.hs
+++ b/fs-api/src/System/FS/API.hs
@@ -146,6 +146,14 @@ data HasFS m h = HasFS {
 
     -- | Useful for better error reporting
   , mkFsErrorPath            :: FsPath -> FsErrorPath
+
+    -- | Create an absolute 'FilePath' from a relative 'FsPath'.
+    --
+    -- This is an escape hatch for creating absolute paths when @m ~'IO'@.
+    --
+    -- Postcondition: Should throw an error for any @m@ that is not @IO@
+    -- (or for which we do not have @'MonadIO' m@).
+  , unsafeToFilePath         :: FsPath -> m FilePath
   }
 
 withFile :: (HasCallStack, MonadThrow m)

--- a/fs-api/src/System/FS/API/Types.hs
+++ b/fs-api/src/System/FS/API/Types.hs
@@ -95,6 +95,7 @@ allowExisting openMode = case openMode of
   Paths
 -------------------------------------------------------------------------------}
 
+-- | A relative path.
 newtype FsPath = UnsafeFsPath { fsPathToList :: [Strict.Text] }
   deriving (Eq, Ord, Generic)
 

--- a/fs-api/src/System/FS/IO.hs
+++ b/fs-api/src/System/FS/IO.hs
@@ -71,6 +71,7 @@ ioHasFS mount = HasFS {
     , renameFile = \fp1 fp2 -> liftIO $ rethrowFsError fp1 $
         Dir.renameFile (root fp1) (root fp2)
     , mkFsErrorPath = fsToFsErrorPath mount
+    , unsafeToFilePath = pure . root
     }
   where
     root :: FsPath -> FilePath

--- a/fs-sim/src/System/FS/Sim/Pure.hs
+++ b/fs-sim/src/System/FS/Sim/Pure.hs
@@ -44,4 +44,5 @@ pureHasFS = HasFS {
     , removeFile               = Mock.removeFile
     , renameFile               = Mock.renameFile
     , mkFsErrorPath            = fsToFsErrorPathUnmounted
+    , unsafeToFilePath         = \_ -> error "pureHasFS:unsafeToFilePath"
     }

--- a/fs-sim/src/System/FS/Sim/STM.hs
+++ b/fs-sim/src/System/FS/Sim/STM.hs
@@ -58,6 +58,7 @@ simHasFS var = HasFS {
     , removeFile               = sim  .  Mock.removeFile
     , renameFile               = sim  .: Mock.renameFile
     , mkFsErrorPath            = fsToFsErrorPathUnmounted
+    , unsafeToFilePath         = \_ -> error "simHasFS:unsafeToFilePath"
     }
   where
     sim :: PureSimFS a -> m a


### PR DESCRIPTION
This is an escape hatch for creating absolute paths when `m ~ IO`. One might need to do this when the filesystem is accessed through a `HasFS`, but one also knows with certainty that `m ~ IO` or we have `MonadIO m`.

One example in `ouroboros-consensus` is the `LMDB` backing store that we implemented for the UTxO-HD feature, which requires knowledge about absolute filepaths.