### PR TITLE
Make GitHub actions build packages with `-Werror`

### DIFF
--- a/.github/workflows/cabal.project.local.haskell
+++ b/.github/workflows/cabal.project.local.haskell
@@ -1,0 +1,7 @@
+ignore-project: False
+
+tests: True
+benchmarks: True
+
+program-options
+  ghc-options: -Werror

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,6 +37,10 @@ jobs:
         cabal-version: ${{ matrix.cabal }}
         cabal-update: false
 
+    - name: "Configure cabal.project.local"
+      run: |
+        cp .github/workflows/cabal.project.local.haskell cabal.project.local
+
     - name: Cabal update
       run: cabal update
 

--- a/cabal.project
+++ b/cabal.project
@@ -15,3 +15,4 @@ packages:
   fs-sim
 
 tests: True
+benchmarks: True

--- a/fs-sim/src/System/FS/Sim/Error.hs
+++ b/fs-sim/src/System/FS/Sim/Error.hs
@@ -534,6 +534,7 @@ mkSimErrorHasFS fsVar errorsVar =
             withErr errorsVar p1 (renameFile p1 p2) "renameFile"
             renameFileE (\e es -> es { renameFileE = e })
         , mkFsErrorPath = fsToFsErrorPathUnmounted
+        , unsafeToFilePath = error "mkSimErrorHasFS:unsafeToFilePath"
         }
 
 -- | Runs a computation provided an 'Errors' and an initial


### PR DESCRIPTION
An incomplete record creation went unnoticed because the GitHub actions workflow was not building the packages with `-Werror`.