### PR TITLE
Repo fixup: various small to medium changes

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -21,11 +21,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - name: Workaround runner image issue
-      if: runner.os == 'Linux'
-      # https://github.com/actions/runner-images/issues/7061
-      run: sudo chown -R $USER /usr/local/.ghcup
-
     - name: Checkout repository
       uses: actions/checkout@v3
 
@@ -48,18 +43,19 @@ jobs:
       id: record-deps
       run: |
         cabal build all --dry-run
+
     - name: Cache cabal store
       uses: actions/cache@v3
       env:
-        cache-name: cache-cabal
+        cache-name: cache-cabal-build
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-build-
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
           ${{ runner.os }}-${{ matrix.ghc }}-
           ${{ runner.os }}-
+
     - name: Install cabal dependencies
       run: cabal build --only-dependencies --enable-tests --enable-benchmarks all
 
@@ -69,6 +65,7 @@ jobs:
     - name: Run tests
       run: cabal test all
 
+  # Check formatting for Haskell files
   stylish-haskell:
     runs-on: ${{ matrix.os }}
 
@@ -80,10 +77,6 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - name: Workaround runner image issue
-      # https://github.com/actions/runner-images/issues/7061
-      run: sudo chown -R $USER /usr/local/.ghcup
-
     - name: Checkout repository
       uses: actions/checkout@v3
 
@@ -91,6 +84,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install fd-find
+
     - name: Setup Haskell
       id: setup-haskell
       uses: haskell/actions/setup@v2
@@ -111,12 +105,12 @@ jobs:
         cache-name: cache-cabal-stylish
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-stylish-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-stylish-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-stylish-
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
           ${{ runner.os }}-${{ matrix.ghc }}-
           ${{ runner.os }}-
+
     - name: Install stylish-haskell
       run: cabal install stylish-haskell --constraint 'stylish-haskell == 0.14.4.0'
 
@@ -124,7 +118,97 @@ jobs:
       run: |
         which stylish-haskell
         stylish-haskell --version
+
     - name: Run stylish-haskell
       run: |
         ./scripts/format-stylish.sh -p . -d
         git diff --exit-code
+
+  # Check formatting for cabal files
+  cabal-fmt:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ["9.2.5"]
+        cabal: ["3.8.1.0"]
+        os: [ubuntu-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install system dependencies (apt-get)
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install fd-find
+
+    - name: Setup Haskell
+      id: setup-haskell
+      uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+        cabal-update: false
+
+    - name: Cabal update
+      run: cabal update
+
+    - name: Setup cabal bin path
+      run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+
+    - name: Cache cabal store
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-cabal-cabal-fmt
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
+
+    - name: Install cabal-fmt
+      run: cabal install cabal-fmt --constraint 'cabal-fmt == 0.1.6'
+
+    - name: Record cabal-fmt version
+      run: |
+        which cabal-fmt
+        cabal-fmt --version
+
+    - name: Run cabal-fmt
+      run: |
+        ./scripts/format-cabal.sh
+        git diff --exit-code
+
+  # Check cabal files
+  cabal-check:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ["9.2.5"]
+        cabal: ["3.8.1.0"]
+        os: [ubuntu-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Haskell
+      id: setup-haskell
+      uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+        cabal-update: false
+
+    - name: Cabal update
+      run: cabal update
+
+    - name: Run cabal check
+      run: |
+        ./scripts/check-cabal.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,50 @@
 # Contributing
 
-See [the contributing file in the `ouroboros-consensus` repository](
-https://github.com/input-output-hk/ouroboros-consensus/blob/main/CONTRIBUTING.md).
+## Building
+
+The project is built using `ghc` and `cabal`, and does not require any external
+dependencies.
+
+```
+cabal update
+cabal build all
+```
+
+## Testing
+
+Tests are run using `cabal`.
+
+```
+cabal build all
+cabal test all
+```
+
+## Code style
+
+There is no strict code style, but try to keep the code style consistent
+throughout the repository and favour readability. Code should be well-documented and well-tested.
+
+## Formatting
+
+We use `stylish-haskell` to format Haskell files, and we use `cabal-fmt` to
+format `*.cabal` files. We also use `cabal check` to sanity check our cabal files. See the helpful scripts in the [scripts folder](./scripts/), and the [`stylish-haskell` configuration file](./.stylish-haskell.yaml).
+
+## Pull requests
+
+The following are requirements for merging a PR into `main`:
+* Each commit should be small and should preferably address one thing. Commit messages should be useful.
+* Document and test your changes.
+* The PR should have a useful description, and it should link issues that it
+  resolves.
+* Changes introduced by the PR should be recorded in the relevant changelog
+  files.
+* PRs should not bundle many unrelated changes.
+* PRs should be approved by at least 1 developer.
+* The PR should pass all CI checks.
+
+## Releases
+
+Releases follow the [Haskell Package Versioning Policy](https://pvp.haskell.org/). We use version numbers consisting of 4 parts, like `A.B.C.D`.
+* `A.B` is the *major* version number. A bump indicates a breaking change.
+* `C` is the *minor* version number. A bump indicates a non-breaking change.
+* `D` is the *patch* version number. A bump indicates a small, non-breaking patch.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,34 @@
 
 # fs-sim
 
-`fs-sim` and `fs-api` are unlikely to work with GHC versions before `ghc-8.10.7`. See the `tested-with` fields in [`fs-api.cabal`](./fs-api/fs-api.cabal) and [`fs-sim.cabal`](./fs-sim/fs-sim.cabal) for the GHC versions that we test with.
+The [`fs-sim`](./fs-sim/README.md) package provides a filesystem simulator that
+facilitates simulation of errors and file corruption. This simulator is
+specially useful for testing purposes, and works well in conjunction with
+[`io-sim`](ps://github.com/input-output-hk/io-sim).
+
+The [`fs-api`](./fs-api/README.md) package provides an abstract interface to
+filesystems. Code that is written using this interface can be run against the
+built-in file system (required to be in `IO`), a simulated file system as
+provided by `fs-sim`, or any other implementation of a file system.
+
+## Note on GHC compatibility
+
+`fs-sim` and `fs-api` are unlikely to work with GHC versions before
+`ghc-8.10.7`. See the `tested-with` fields in
+[`fs-api.cabal`](./fs-api/fs-api.cabal) and
+[`fs-sim.cabal`](./fs-sim/fs-sim.cabal) for the GHC versions that we test with.
+
+## Credits
+
+Previously, the packages in this repository lived in the [`ouroboros-network`
+repository](https://github.com/input-output-hk/ouroboros-network). [This
+commit](https://github.com/input-output-hk/ouroboros-network/commit/0659e7b7ef66b01763cdf15c2f8777a9394c248d)
+marks the migration of the packages from `ouroboros-network` to the current
+repository. Since the commit history was not carried over to this repository, we
+give credit for the packages to the original authors and frequent contributors, which include:
+
+* Thomas Winant (@mrBliss)
+* Edsko de Vries (@edsko)
+* Kostas Dermentzis (@kderme)
+* Alfredo di Napoli (@adinapoli-iohk)
+

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,4 +1,0 @@
-# Release process
-
-See the [consensus release
-process](https://github.com/input-output-hk/ouroboros-consensus/blob/master/docs/ReleaseProcess.md).

--- a/fs-api/README.md
+++ b/fs-api/README.md
@@ -1,1 +1,26 @@
 # fs-api
+
+The `fs-api` package provides an abstract interface to filesystems. The abstract
+interface is a datatype called `HasFS`, which is parameterised over a monad `m`
+that filesystem operations run in, and the type of file handles `h`.
+`removeFile` is an example of a filesystem operation in this interface.
+
+```haskell
+data HasFS m h = HasFS {
+    {- omitted -}
+    -- | Remove the file (which must exist)
+  , removeFile               :: HasCallStack => FsPath -> m ()
+    {- omitted -}
+  }
+```
+
+Code that is written using this interface can be run against any implementation
+of a file system. The `System.FS.IO` module provides a function for initialising
+a `HasFS` interface for the built-in filesystem.
+
+```haskell
+ioHasFS :: MonadIO m => MountPoint -> HasFS m HandleIO
+```
+
+Note that `ioHasFS` requires some context in the form of a `MountPoint`: the
+base directory in which the filesystem operations should be run.

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -1,19 +1,20 @@
-cabal-version:      3.0
+cabal-version:   3.0
+name:            fs-api
+version:         0.1.0.0
+synopsis:        API for file systems
+description:     API for file systems.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
 
-name:               fs-api
-version:            0.1.0.0
-synopsis:           API for file systems
-description:        API for file systems.
-license:            Apache-2.0
-license-files:      LICENSE
-                    NOTICE
-copyright:          2019-2023 Input Output Global Inc (IOG)
-author:             IOHK Engineering Team
-maintainer:         operations@iohk.io
-category:           System
-build-type:         Simple
-extra-doc-files:    CHANGELOG.md
-tested-with:        GHC == { 8.10.7, 9.2.5 }
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        System
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+tested-with:     GHC ==8.10.7 || ==9.2.5
 
 source-repository head
   type:     git
@@ -26,49 +27,48 @@ flag asserts
   default:     False
 
 library
-  hs-source-dirs:     src
+  hs-source-dirs:   src
 
   if os(windows)
-    hs-source-dirs:   src-win32
+    hs-source-dirs: src-win32
+
   else
-    hs-source-dirs:   src-unix
+    hs-source-dirs: src-unix
 
-  exposed-modules:    System.FS.API
-                    , System.FS.API.Types
-                    , System.FS.CRC
-                    , System.FS.Handle
-                    , System.FS.IO
-                    , System.IO.FS
-                    , Util.CallStack
-                    , Util.Condense
+  exposed-modules:
+    System.FS.API
+    System.FS.API.Types
+    System.FS.CRC
+    System.FS.Handle
+    System.FS.IO
+    System.IO.FS
+    Util.CallStack
+    Util.Condense
 
-  default-language:   Haskell2010
-
-  build-depends:      base        >=4.14  && <4.17
-                    , bytestring  >=0.10  && <0.12
-                    , containers  >=0.5   && <0.7
-                    , deepseq
-                    , digest
-                    , directory   >=1.3   && <1.4
-                    , filepath    >=1.4   && <1.5
-                    , io-classes ^>=0.3
-                    , text        >=1.2   && <1.3
+  default-language: Haskell2010
+  build-depends:
+    , base        >=4.14 && <4.17
+    , bytestring  >=0.10 && <0.12
+    , containers  >=0.5  && <0.7
+    , deepseq
+    , digest
+    , directory   >=1.3  && <1.4
+    , filepath    >=1.4  && <1.5
+    , io-classes  ^>=0.3
+    , text        >=1.2  && <1.3
 
   if os(windows)
-    build-depends:    Win32            >= 2.6.1.0
-  else
-    build-depends:    unix
-                    , unix-bytestring  >= 0.4.0
+    build-depends: Win32 >=2.6.1.0
 
-  ghc-options:        -Wall
-                      -Wcompat
-                      -Wincomplete-uni-patterns
-                      -Wincomplete-record-updates
-                      -Wpartial-fields
-                      -Widentities
-                      -Wredundant-constraints
-                      -Wmissing-export-lists
-                      -Wunused-packages
+  else
+    build-depends:
+      , unix
+      , unix-bytestring  >=0.4.0
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
 
   if flag(asserts)
-    ghc-options:      -fno-ignore-asserts
+    ghc-options: -fno-ignore-asserts

--- a/fs-api/src/System/FS/API.hs
+++ b/fs-api/src/System/FS/API.hs
@@ -38,7 +38,7 @@ import           System.FS.API.Types
 import           Util.CallStack
 
 {------------------------------------------------------------------------------
- Typeclass which abstracts over the filesystem
+  Record that abstracts over the filesystem
 ------------------------------------------------------------------------------}
 
 data HasFS m h = HasFS {

--- a/fs-sim/README.md
+++ b/fs-sim/README.md
@@ -1,1 +1,28 @@
 # fs-sim
+
+The `fs-sim` package provides a filesystem simulator that facilitates
+simulation of errors and file corruption. This simulator is specially useful for
+testing purposes, and works well in conjunction with
+[`io-sim`](ps://github.com/input-output-hk/io-sim).
+
+Code that is written using the abstract filesystem interface (`HasFS`) that is
+provided by the parent package `fs-api` can be run against any of the simulator
+implementations provided by `fs-sim`. `fs-sim` currently provides three
+simulators:
+* `System.FS.Sim.Pure` provides a pure implementation.
+* `System.FS.Sim.STM` provides an implementation that uses STM.
+* `System.FS.im.Error` provides an implementation that uses STM, but can also
+  simulate errors and file corruption.
+
+```haskell
+pureHasFS :: HasFS PureSimFS Mock.HandleMock
+
+simHasFS :: forall m. (MonadSTM m, MonadThrow m)
+         => StrictTVar m MockFS
+         -> HasFS m HandleMock
+
+mkSimErrorHasFS :: forall m. (MonadSTM m, MonadThrow m)
+                => StrictTVar m MockFS
+                -> StrictTVar m Errors
+                -> HasFS m HandleMock
+```

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -1,19 +1,20 @@
-cabal-version:      3.0
+cabal-version:   3.0
+name:            fs-sim
+version:         0.1.0.0
+synopsis:        Simulated file systems
+description:     Simulated file systems.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
 
-name:               fs-sim
-version:            0.1.0.0
-synopsis:           Simulated file systems
-description:        Simulated file systems.
-license:            Apache-2.0
-license-files:      LICENSE
-                    NOTICE
-copyright:          2019-2023 Input Output Global Inc (IOG)
-author:             IOHK Engineering Team
-maintainer:         operations@iohk.io
-category:           Testing
-build-type:         Simple
-extra-doc-files:    CHANGELOG.md
-tested-with:        GHC == { 8.10.7, 9.2.5 }
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOHK Engineering Team
+maintainer:      operations@iohk.io
+category:        Testing
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+tested-with:     GHC ==8.10.7 || ==9.2.5
 
 source-repository head
   type:     git
@@ -26,74 +27,67 @@ flag asserts
   default:     False
 
 library
-  hs-source-dirs:     src
+  hs-source-dirs:   src
+  exposed-modules:
+    System.FS.Sim.Error
+    System.FS.Sim.FsTree
+    System.FS.Sim.MockFS
+    System.FS.Sim.Pure
+    System.FS.Sim.STM
 
-  exposed-modules:    System.FS.Sim.Error
-                    , System.FS.Sim.FsTree
-                    , System.FS.Sim.MockFS
-                    , System.FS.Sim.Pure
-                    , System.FS.Sim.STM
+  default-language: Haskell2010
+  build-depends:
+    , base               >=4.14 && <4.17
+    , base16-bytestring
+    , bytestring         >=0.10 && <0.12
+    , containers         >=0.5  && <0.7
+    , fs-api
+    , io-classes         ^>=0.3
+    , mtl
+    , QuickCheck
+    , strict-stm
+    , text               >=1.2  && <1.3
 
-  default-language:   Haskell2010
-
-  build-depends:      base        >=4.14  && <4.17
-                    , base16-bytestring
-                    , bytestring  >=0.10  && <0.12
-                    , containers  >=0.5   && <0.7
-                    , fs-api
-                    , io-classes ^>=0.3
-                    , mtl
-                    , QuickCheck
-                    , strict-stm
-                    , text        >=1.2   && <1.3
-
-  ghc-options:        -Wall
-                      -Wcompat
-                      -Wincomplete-uni-patterns
-                      -Wincomplete-record-updates
-                      -Wpartial-fields
-                      -Widentities
-                      -Wredundant-constraints
-                      -Wmissing-export-lists
-                      -Wunused-packages
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
 
   if flag(asserts)
-    ghc-options:      -fno-ignore-asserts
-    cpp-options:      -DENABLE_ASSERTIONS
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
 
 test-suite fs-sim-test
-  type:               exitcode-stdio-1.0
-  hs-source-dirs:     test
-  main-is:            Main.hs
-  other-modules:      Test.System.FS.Sim.FsTree
-                    , Test.System.FS.StateMachine
-                    , Test.Util.RefEnv
-  default-language:   Haskell2010
-  build-depends:      base >=4.14 && <4.17
-                    , bifunctors
-                    , bytestring
-                    , containers
-                    , fs-api
-                    , fs-sim
-                    , generics-sop
-                    , pretty-show
-                    , QuickCheck
-                    , quickcheck-state-machine
-                    , random
-                    , tasty
-                    , tasty-hunit
-                    , tasty-quickcheck
-                    , temporary
-                    , text
-                    , tree-diff
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  other-modules:
+    Test.System.FS.Sim.FsTree
+    Test.System.FS.StateMachine
+    Test.Util.RefEnv
 
-  ghc-options:        -Wall
-                      -Wcompat
-                      -Wincomplete-uni-patterns
-                      -Wincomplete-record-updates
-                      -Wpartial-fields
-                      -Widentities
-                      -Wredundant-constraints
-                      -Wmissing-export-lists
-                      -Wunused-packages
-                      -fno-ignore-asserts
+  default-language: Haskell2010
+  build-depends:
+    , base                      >=4.14 && <4.17
+    , bifunctors
+    , bytestring
+    , containers
+    , fs-api
+    , fs-sim
+    , generics-sop
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine
+    , random
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , temporary
+    , text
+    , tree-diff
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -fno-ignore-asserts

--- a/scripts/check-cabal.sh
+++ b/scripts/check-cabal.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+for x in $(find . -name '*.cabal' | grep -v dist-newstyle | cut -c 3-); do
+  (
+    d=$(dirname $x)
+    echo "== $d =="
+    cd $d
+    cabal check
+  )
+done

--- a/scripts/format-cabal.sh
+++ b/scripts/format-cabal.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fdfind -p . -e cabal -x cabal-fmt -i

--- a/scripts/format-stylish.sh
+++ b/scripts/format-stylish.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 PARGS="-p ."
 CARGS=""
 
@@ -13,8 +15,6 @@ do
 done
 
 echo "Running stylish-haskell script with arguments: $PARGS $CARGS"
-
-set -euo pipefail
 
 export LC_ALL=C.UTF-8
 


### PR DESCRIPTION
CI:
* Remove "workaround" steps from the workflow file.
* Simplify keys used for caching
* Add missing newlines to workflow file.
* Add a `cabal-fmt` job (with accompanying script).
* Add a `cabal check` job (with accompanying script).

Documentation:
* Fill in `README`s.
* Fill in `CONTRIBUTING.md`.
* Remove `RELEASE_PROCESS.md` in favour of the `Releases` section in
  `CONTRIBUTING.md`.

Formatting:
* Run `cabal-fmt` on `fs-api.cabal` and `fs-sim.cabal`.

Others:
* Update section header in the `System.FS.API` module.