### PR TITLE
coot/io sim 1.0.0.1

### DIFF
--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -54,7 +54,7 @@ library
     , digest
     , directory   >=1.3  && <1.4
     , filepath    >=1.4  && <1.5
-    , io-classes  >=0.3  && <0.6
+    , io-classes  >=0.3  && <1.1
     , text        >=1.2  && <1.3
 
   if os(windows)

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -77,7 +77,7 @@ test-suite fs-sim-test
     , generics-sop
     , pretty-show
     , QuickCheck
-    , quickcheck-state-machine
+    , quickcheck-state-machine  >=0.7.2
     , random
     , tasty
     , tasty-hunit

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -42,10 +42,10 @@ library
     , bytestring         >=0.10 && <0.12
     , containers         >=0.5  && <0.7
     , fs-api             ^>=0.1
-    , io-classes         >=0.3  && <0.6
+    , io-classes         >=0.3  && <1.1
     , mtl
     , QuickCheck
-    , strict-stm         >=0.3  && <0.6
+    , strict-stm         >=0.3  && <1.1
     , text               >=1.2  && <1.3
 
   ghc-options:

--- a/fs-sim/test/Test/System/FS/StateMachine.hs
+++ b/fs-sim/test/Test/System/FS/StateMachine.hs
@@ -1446,7 +1446,7 @@ prop_sequential tmpDir = withMaxSuccess 10000 $
           let mount = MountPoint tstTmpDir
               sm'   = sm mount
 
-          (hist, model, res) <- QSM.runCommands' sm' cmds
+          (hist, model, res) <- QSM.runCommands' (pure sm') cmds
 
           -- Close all open handles
           forM_ (RE.keys (knownHandles model)) $ F.close . handleRaw . QSM.concrete


### PR DESCRIPTION
- Relax upper bounds for io-classes & strict-stm
- fs-sim: doesn't build with quickcheck-state-machine < 0.7
