### PR TITLE
Make it build with ghc-9.6

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.5"]
-        cabal: ["3.8.1.0"]
+        ghc: ["8.10.7", "9.2.7", "9.6.1"]
+        cabal: ["3.10.1.0"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -15,4 +15,13 @@ packages:
   fs-sim
 
 tests: True
+test-show-details: direct
 benchmarks: True
+
+-- HEAD of git has been fixed buy not yet released to Hackage.
+-- Only used in tests.
+source-repository-package
+  type: git
+  location: https://github.com/stevana/quickcheck-state-machine
+  tag: 7499a90102e78b1b67bc37635618cc8c1321b1f4
+  --sha256: 12bvc984lwlj9vbfnl1ihs4drafnir94d42wbm9mdrqlb7llfnlx

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for fs-api
 
+### 0.1.0.3 -- 2023-05025
+
+* Fix for ghc-9.6
+# Require `unix >= 2.8` dependency.
+
 ## 0.1.0.1 -- 2023-04-24
 
 ### Non-breaking

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            fs-api
-version:         0.1.0.1
+version:         0.1.0.2
 synopsis:        API for file systems
 description:     API for file systems.
 license:         Apache-2.0

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -14,7 +14,7 @@ maintainer:      operations@iohk.io
 category:        System
 build-type:      Simple
 extra-doc-files: CHANGELOG.md
-tested-with:     GHC ==8.10.7 || ==9.2.5
+tested-with:     GHC ==8.10.7 || ==9.2.5 || ==9.6.1
 
 source-repository head
   type:     git
@@ -47,7 +47,7 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base        >=4.14 && <4.17
+    , base        >=4.14 && <4.19
     , bytestring  >=0.10 && <0.12
     , containers  >=0.5  && <0.7
     , deepseq
@@ -55,14 +55,14 @@ library
     , directory   >=1.3  && <1.4
     , filepath    >=1.4  && <1.5
     , io-classes  >=0.3  && <1.2
-    , text        >=1.2  && <1.3
+    , text        >=2.0  && <2.1
 
   if os(windows)
     build-depends: Win32 >=2.6.1.0
 
   else
     build-depends:
-      , unix
+      , unix             >=2.8
       , unix-bytestring  >=0.4.0
 
   ghc-options:

--- a/fs-api/src-unix/System/IO/FS.hs
+++ b/fs-api/src-unix/System/IO/FS.hs
@@ -45,29 +45,33 @@ defaultFileFlags = Posix.OpenFileFlags {
     , Posix.noctty    = False
     , Posix.nonBlock  = False
     , Posix.trunc     = False
+    , Posix.nofollow  = False
+    , Posix.creat     = Nothing
+    , Posix.cloexec   = False
+    , Posix.directory = False
+    , Posix.sync      = False
     }
 
 -- | Opens a file from disk.
 open :: FilePath -> OpenMode -> IO Fd
-open fp openMode = Posix.openFd fp posixOpenMode fileMode fileFlags
+open fp openMode = Posix.openFd fp posixOpenMode fileFlags
   where
-    (posixOpenMode, fileMode, fileFlags) = case openMode of
+    (posixOpenMode, fileFlags) = case openMode of
       ReadMode         -> ( Posix.ReadOnly
-                          , Nothing
                           , defaultFileFlags
                           )
       AppendMode    ex -> ( Posix.WriteOnly
-                          , Just Posix.stdFileMode
                           , defaultFileFlags { Posix.append = True
-                                             , Posix.exclusive = isExcl ex }
+                                             , Posix.exclusive = isExcl ex
+                                             , Posix.creat = Just Posix.stdFileMode }
                           )
       ReadWriteMode ex -> ( Posix.ReadWrite
-                          , Just Posix.stdFileMode
-                          , defaultFileFlags { Posix.exclusive = isExcl ex }
+                          , defaultFileFlags { Posix.exclusive = isExcl ex
+                                             , Posix.creat = Just Posix.stdFileMode }
                           )
       WriteMode     ex -> ( Posix.ReadWrite
-                          , Just Posix.stdFileMode
-                          , defaultFileFlags { Posix.exclusive = isExcl ex }
+                          , defaultFileFlags { Posix.exclusive = isExcl ex
+                                             , Posix.creat = Just Posix.stdFileMode }
                           )
 
     isExcl AllowExisting = False

--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for fs-sim
 
+### 0.1.0.3 -- 2023-05025
+
+* Fix for ghc-9.6
+
 ## 0.1.0.1 -- 2023-04-24
 
 ### Non-breaking

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -14,7 +14,7 @@ maintainer:      operations@iohk.io
 category:        Testing
 build-type:      Simple
 extra-doc-files: CHANGELOG.md
-tested-with:     GHC ==8.10.7 || ==9.2.5
+tested-with:     GHC ==8.10.7 || ==9.2.5 || ==9.6.1
 
 source-repository head
   type:     git
@@ -37,7 +37,7 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base               >=4.14 && <4.17
+    , base               >=4.14 && <4.19
     , base16-bytestring
     , bytestring         >=0.10 && <0.12
     , containers         >=0.5  && <0.7
@@ -46,7 +46,7 @@ library
     , mtl
     , QuickCheck
     , strict-stm         >=0.3  && <1.2
-    , text               >=1.2  && <1.3
+    , text               >=2.0  && <2.1
 
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns
@@ -68,7 +68,7 @@ test-suite fs-sim-test
 
   default-language: Haskell2010
   build-depends:
-    , base                      >=4.14  && <4.17
+    , base
     , bifunctors
     , bytestring
     , containers

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            fs-sim
-version:         0.1.0.1
+version:         0.1.0.2
 synopsis:        Simulated file systems
 description:     Simulated file systems.
 license:         Apache-2.0

--- a/fs-sim/src/System/FS/Sim/MockFS.hs
+++ b/fs-sim/src/System/FS/Sim/MockFS.hs
@@ -57,8 +57,9 @@ module System.FS.Sim.MockFS (
   , MockFS
   ) where
 
-import           Control.Monad.Except
-import           Control.Monad.State
+import           Control.Monad (unless, void, when)
+import           Control.Monad.Except (MonadError, throwError)
+import           Control.Monad.State (MonadState, get, gets, put)
 import           Data.Bifunctor
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS


### PR DESCRIPTION
It currently uses `quickcheck-state-machine` (github HEAD, but not yet released to Hackage) as a `source-repository-package`, but that package is only used in tests so that should not prevent this being merged and uploaded to CHaP.