### PR TITLE
Add alternative initialisation of simulated file system

### DIFF
--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for fs-sim
 
+## Next version
+
+### Non-breaking
+
+* Add `simHasFS'` and `mkSimErrorHasFS'`, which are alternatives to `simHasFS`
+  and `mkSimErrorHasFS` that create `TVar`s internally.
+
 ## 0.1.0.2 -- 2023-05-25
 
 * Enable building with ghc-9.6

--- a/fs-sim/src/System/FS/Sim/Error.hs
+++ b/fs-sim/src/System/FS/Sim/Error.hs
@@ -12,6 +12,7 @@
 module System.FS.Sim.Error (
     -- * Simulate Errors monad
     mkSimErrorHasFS
+  , mkSimErrorHasFS'
   , runSimErrorFS
   , withErrors
     -- * Streams
@@ -475,6 +476,14 @@ instance Arbitrary Errors where
 {-------------------------------------------------------------------------------
   Simulate Errors monad
 -------------------------------------------------------------------------------}
+
+-- | Alternative to 'mkSimErrorHasFS' that creates 'TVar's internally.
+mkSimErrorHasFS' :: (MonadSTM m, MonadThrow m)
+                => MockFS
+                -> Errors
+                -> m (HasFS m HandleMock)
+mkSimErrorHasFS' mockFS errs =
+    mkSimErrorHasFS <$> newTVarIO mockFS <*> newTVarIO errs
 
 -- | Introduce possibility of errors
 --

--- a/fs-sim/src/System/FS/Sim/STM.hs
+++ b/fs-sim/src/System/FS/Sim/STM.hs
@@ -5,6 +5,7 @@
 module System.FS.Sim.STM (
     runSimFS
   , simHasFS
+  , simHasFS'
   ) where
 
 import           Control.Concurrent.Class.MonadSTM.Strict
@@ -31,8 +32,14 @@ runSimFS :: (MonadSTM m, MonadThrow m)
 runSimFS fs act = do
     var <- newTVarIO fs
     a   <- act (simHasFS var)
-    fs' <- atomically (readTVar var)
+    fs' <- readTVarIO var
     return (a, fs')
+
+-- | Alternative to 'simHasFS' that creates 'TVar's internally.
+simHasFS' :: (MonadSTM m, MonadThrow m)
+         => MockFS
+         -> m (HasFS m HandleMock)
+simHasFS' mockFS = simHasFS <$> newTVarIO mockFS
 
 -- | Equip @m@ with a @HasFs@ instance using the mock file system
 simHasFS :: forall m. (MonadSTM m, MonadThrow m)


### PR DESCRIPTION
This PR adds `simHasFS'` and `mkSimErrorHasFS'`. These functions are alternatives to `simHasFS` and `mkSimErrorHasFS`. `simHasFS` and `mkSimErrorHasFS` are pure functions that require some parameters wrapped inside `TVar`s. `simHasFS'` and `mkSimErrorHasFS'` are monadic functions that require bare parameters (without `TVar`s), and they will create the `TVar`s internally.