### PR TITLE
Improve generation, shrinking and showing for the `Stream` type.

### DIFF
--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -5,11 +5,20 @@
 ### Breaking
 
 * Move `Stream`-related functions to new `System.FS.Sim.Stream` module.
+* Remove `Semigroup` and `Monoid` instances for `Stream` and `Errors` types.
+* Overhaul `Stream` type and related functions. The `Stream` type now behaves
+  similarly to `Test.QuickCheck`'s `InfiniteList`, which improves showing,
+  generation and shrinking.
 
 ### Non-breaking
 
 * Add `simHasFS'` and `mkSimErrorHasFS'`, which are alternatives to `simHasFS`
   and `mkSimErrorHasFS` that create `TVar`s internally.
+* Add new `emptyErrors` function.
+* Adapt the `Errors` type to use the overhauled `Stream` type. As a bonus:
+  * Arbitrary `Errors` now contain infinite error `Stream`s by default, instead
+    of finite ones.
+  * Shrinking of `Errors` that contain infinite error `Stream`s now terminates.
 
 ### Patch
 

--- a/fs-sim/src/System/FS/Sim/Stream.hs
+++ b/fs-sim/src/System/FS/Sim/Stream.hs
@@ -1,17 +1,29 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
+-- | Possibly infinite streams of @'Maybe' a@s.
 module System.FS.Sim.Stream (
-    Stream (..)
-  , always
-  , mkStream
-  , mkStreamGen
-  , null
+    -- * Streams
+    Stream
+    -- * Running
   , runStream
+    -- * Construction
+  , always
+  , empty
+  , mkInfinite
+  , repeating
+  , unsafeMkFinite
+    -- * Query
+  , null
+    -- * Generation and shrinking
+  , genFinite
+  , genInfinite
+  , genMaybe
+  , genMaybe'
+  , shrinkStream
   ) where
 
 import           Control.Monad (replicateM)
-import           Data.List (dropWhileEnd)
-import           Data.Maybe (isNothing)
 import           Prelude hiding (null)
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck (Gen)
@@ -20,55 +32,137 @@ import           Test.QuickCheck (Gen)
   Streams
 -------------------------------------------------------------------------------}
 
--- | A 'Stream' is a possibly infinite stream of @'Maybe' a@s.
-newtype Stream a = Stream { getStream :: [Maybe a] }
-    deriving (Show, Functor)
+-- | A 'Stream' is a stream of @'Maybe' a@s, which is /possibly/ infinite or
+-- /definitely/ finite.
+--
+-- Finiteness is tracked internally and used for 'QC.shrink'ing and the 'Show'
+-- instance.
+data Stream a = Stream {
+      -- | Info about the size of the stream.
+      _streamInternalInfo :: InternalInfo
+    , _getStream          :: [Maybe a]
+    }
+  deriving Functor
 
-instance Semigroup (Stream a) where
-  Stream s1 <> Stream s2 = Stream (zipWith pickLast s1 s2)
-    where
-      pickLast (Just x) Nothing = Just x
-      pickLast _        mbY     = mbY
+-- | Tag for 'Stream's that describes whether it is either /definitely/ a finite
+-- stream, or /possibly/ an infinite stream.
+--
+-- Useful for the 'Show' instance of 'Stream': when a 'Stream' is /definitely/
+-- finite, we can safely print the full stream.
+data InternalInfo = Infinite | Finite
 
-instance Monoid (Stream a) where
-  mempty  = Stream (repeat Nothing)
-  mappend = (<>)
+-- | Fully shows a 'Stream' if it is /definitely/ finite, or prints a
+-- placeholder string if it is /possibly/ infinite.
+instance Show a => Show (Stream a) where
+  showsPrec n (Stream info xs) = case info of
+      Infinite -> ("<infinite stream>" ++)
+      Finite   -> (if n > 10 then ('(':) else id)
+                . shows xs
+                . (" ++ ..." ++)
+                . (if n > 10 then (')':) else id)
 
--- | Create a 'Stream' based on the given possibly infinite list of @'Maybe'
--- a@s.
-mkStream :: [Maybe a] -> Stream a
-mkStream = Stream
+{-------------------------------------------------------------------------------
+  Running
+-------------------------------------------------------------------------------}
 
 -- | Advance the 'Stream'. Return the @'Maybe' a@ and the remaining 'Stream'.
+--
+-- Returns 'Nothing' by default if the 'Stream' is empty.
 runStream :: Stream a -> (Maybe a, Stream a)
-runStream s@(Stream [])     = (Nothing, s)
-runStream   (Stream (a:as)) = (a, Stream as)
+runStream s@(Stream _    []    ) = (Nothing, s)
+runStream   (Stream info (a:as)) = (a, Stream info as)
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+-- | Make an empty 'Stream'.
+empty :: Stream a
+empty = Stream Finite []
 
 -- | Make a 'Stream' that always generates the given @a@.
 always :: a -> Stream a
-always a = Stream (repeat (Just a))
+always x = Stream Infinite (repeat (Just x))
 
--- | Make a 'Stream' generator based on a @a@ generator.
+-- | Make a 'Stream' that infinitely repeats the given list.
+repeating :: [Maybe a] -> Stream a
+repeating xs = Stream Infinite $ concat (repeat xs)
+
+-- | UNSAFE: Make a 'Stream' that is marked as definitely finite.
 --
--- The generator generates a finite stream of 10 elements, where each element
--- has a chance of being either 'Nothing' or an element generated with the
--- given @a@ generator (wrapped in a 'Just').
---
--- The first argument is the likelihood (as used by 'QC.frequency') of a
--- 'Just' where 'Nothing' has likelihood 2.
-mkStreamGen :: Int -> Gen a -> Gen (Stream a)
-mkStreamGen justLikelihood genA =
-    mkStream . dropWhileEnd isNothing <$> replicateM 10 mbGenA
-  where
-    mbGenA = QC.frequency
-      [ (2, return Nothing)
-      , (justLikelihood, Just <$> genA)
-      ]
+-- This is unsafe since a user can pass in any list, and evaluating
+-- 'Test.QuickCheck.shrink' or 'show' on the resulting 'Stream' will diverge. It
+-- is the user's responsibility to only pass in a finite list.
+unsafeMkFinite :: [Maybe a] -> Stream a
+unsafeMkFinite = Stream Finite
+
+-- | Make a 'Stream' that is marked as possibly infinite.
+mkInfinite :: [Maybe a] -> Stream a
+mkInfinite = Stream Infinite
+
+{-------------------------------------------------------------------------------
+  Query
+-------------------------------------------------------------------------------}
 
 -- | Return 'True' if the stream is empty.
 --
 -- A stream consisting of only 'Nothing's (even if it is only one) is not
 -- considered to be empty.
 null :: Stream a -> Bool
-null (Stream []) = True
-null _           = False
+null (Stream _ []) = True
+null _             = False
+
+{-------------------------------------------------------------------------------
+  Generation and shrinking
+-------------------------------------------------------------------------------}
+
+-- | Shrink a stream like it is an 'Test.QuickCheck.InfiniteList'.
+--
+-- Possibly infinite streams are shrunk differently than lists that are
+-- definitely finite, which is to ensure that shrinking terminates.
+-- * Possibly infinite streams are shrunk by taking finite prefixes of the
+--  argument stream. As such, shrinking a possibly infinite stream creates
+--  definitely finite streams.
+-- * Definitely finite streams are shrunk like lists are shrunk normally,
+--   preserving that the created streams are still definitely finite.
+shrinkStream :: Stream a -> [Stream a]
+shrinkStream (Stream info xs0) = case info of
+    Infinite -> Stream Finite <$> [take n xs0 | n <- map (2^) [0 :: Int ..]]
+    Finite   -> Stream Finite <$> QC.shrinkList (const []) xs0
+
+-- | Make a @'Maybe' a@ generator based on an @a@ generator.
+--
+-- Each element has a chance of being either 'Nothing' or an element generated
+-- with the given @a@ generator (wrapped in a 'Just').
+--
+-- The first argument is the likelihood (as used by 'QC.frequency') of a
+-- 'Just' where 'Nothing' has likelihood 2.
+genMaybe ::
+     Int   -- ^ Likelihood of 'Nothing'
+  -> Int   -- ^ Likelihood of @'Just' a@
+  -> Gen a
+  -> Gen (Maybe a)
+genMaybe nLi jLi genA = QC.frequency
+    [ (nLi, return Nothing)
+    , (jLi, Just <$> genA)
+    ]
+
+-- | Like 'genMaybe', but with the likelihood of 'Nothing' fixed to @2@. 'QC.frequency'
+genMaybe' ::
+     Int   -- ^ Likelihood of @'Just' a@
+  -> Gen a
+  -> Gen (Maybe a)
+genMaybe' = genMaybe 2
+
+-- | Generate a finite 'Stream' of length @n@.
+genFinite ::
+     Int           -- ^ Requested size of finite stream. Tip: use 'genMaybe'.
+  -> Gen (Maybe a)
+  -> Gen (Stream a)
+genFinite n gen = Stream Finite <$> replicateM n gen
+
+-- | Generate an infinite 'Stream'.
+genInfinite ::
+     Gen (Maybe a)  -- ^ Tip: use 'genMaybe'.
+  -> Gen (Stream a)
+genInfinite gen = Stream Infinite <$> QC.listOf gen


### PR DESCRIPTION
Some things I noticed when looking into the `Errors` and `Stream` module:
* `Stream`s can be possibly infinite, but in reality we only use finite `Stream`s for `Error`s.
* Shrinking diverges for infinite `Stream`s.
* When we `show` a `Stream`, we just `show` a prefix of the `Stream`. 

This PR updates `Stream` to behave much like [`Test.QuickCheck.InfiniteList`](https://hackage.haskell.org/package/QuickCheck-2.14.2/docs/Test-QuickCheck.html#t:InfiniteList) in terms of generation, shrinking and showing. Furthermore, we clean up the module and establish a (safe/unsafe) interface to `Stream`s.