### PR TITLE
Increase lower bound of ByteString dependency

### DIFF
--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -47,15 +47,15 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base        >=4.14 && <4.19
-    , bytestring  >=0.10 && <0.12
-    , containers  >=0.5  && <0.7
+    , base        >=4.14   && <4.19
+    , bytestring  >=0.11.3 && <0.12
+    , containers  >=0.5    && <0.7
     , deepseq
     , digest
-    , directory   >=1.3  && <1.4
-    , filepath    >=1.4  && <1.5
-    , io-classes  >=0.3  && <1.2
-    , text        >=1.2  && <2.1
+    , directory   >=1.3    && <1.4
+    , filepath    >=1.4    && <1.5
+    , io-classes  >=0.3    && <1.2
+    , text        >=1.2    && <2.1
 
   if os(windows)
     build-depends: Win32 >=2.6.1.0


### PR DESCRIPTION
This was needed because for some reason, when submitted to the cardano-haskell-packages CI, it was pulling in `filepath-1.4.100.3` and `bytestring-0.10.12.0` while the former has the constraint `bytestring>=0.11.3.0`.

I have no idea why this was happening.