### PR TITLE
Move `ioHasFS` related modules into an internal hierachy.

### DIFF
--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for fs-api
 
+## next version
+
+### Breaking
+
+* Modules that are required for `ioHasFS` should never be used by client code.
+  For this reason, we move the relevant modules into an `Internal` hierarchy.
+  * Move the `System.IO.FS` module to `System.FS.IO.Internal`.
+  * Move the `System.FS.Handle` module to `System.FS.IO.Internal.Handle`.
+
 ## 0.1.0.3 -- 2023-06-2
 
 ### Patch

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -34,9 +34,9 @@ library
     System.FS.API
     System.FS.API.Types
     System.FS.CRC
-    System.FS.Handle
     System.FS.IO
-    System.IO.FS
+    System.FS.IO.Internal
+    System.FS.IO.Internal.Handle
     Util.CallStack
     Util.Condense
 

--- a/fs-api/src-unix/System/FS/IO/Internal.hs
+++ b/fs-api/src-unix/System/FS/IO/Internal.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE CPP            #-}
 {-# LANGUAGE PackageImports #-}
 
-module System.IO.FS (
+-- | This is meant to be used for the implementation of HasFS instances and not
+-- directly by client code.
+module System.FS.IO.Internal (
     FHandle
   , close
   , getSize
@@ -24,7 +26,7 @@ import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Ptr)
 import           System.FS.API.Types (AllowExisting (..), FsError,
                      OpenMode (..), SeekMode (..), sameFsError)
-import           System.FS.Handle
+import           System.FS.IO.Internal.Handle
 import qualified System.Posix as Posix
 import           System.Posix (Fd)
 import           System.Posix.IO.ByteString.Ext (fdPreadBuf)

--- a/fs-api/src-win32/System/FS/IO/Internal.hs
+++ b/fs-api/src-win32/System/FS/IO/Internal.hs
@@ -1,5 +1,8 @@
 {-# OPTIONS_GHC -Wno-dodgy-imports #-}
-module System.IO.FS (
+
+-- | This is meant to be used for the implementation of HasFS instances and not
+-- directly by client code.
+module System.FS.IO.Internal (
     FHandle
   , close
   , getSize
@@ -22,7 +25,7 @@ import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Int64, Ptr)
 import           System.FS.API.Types (AllowExisting (..), FsError (..),
                      FsErrorType (..), OpenMode (..), SeekMode (..))
-import           System.FS.Handle
+import           System.FS.IO.Internal.Handle
 import           System.Win32
 
 type FHandle = HandleOS HANDLE

--- a/fs-api/src/System/FS/IO.hs
+++ b/fs-api/src/System/FS/IO.hs
@@ -15,8 +15,8 @@ import           GHC.Stack
 import qualified System.Directory as Dir
 import           System.FS.API
 import           System.FS.API.Types
-import qualified System.FS.Handle as H
-import qualified System.IO.FS as F
+import qualified System.FS.IO.Internal as F
+import qualified System.FS.IO.Internal.Handle as H
 
 {-------------------------------------------------------------------------------
   I/O implementation of HasFS

--- a/fs-api/src/System/FS/IO/Internal/Handle.hs
+++ b/fs-api/src/System/FS/IO/Internal/Handle.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE LambdaCase #-}
 
--- | This is meant to be used for the implementation of HasFS
--- instances and not directly by client code.
-module System.FS.Handle (
+-- | This is meant to be used for the implementation of HasFS instances and not
+-- directly by client code.
+module System.FS.IO.Internal.Handle (
     HandleOS (..)
   , closeHandleOS
   , isHandleClosedException

--- a/fs-sim/test/Test/System/FS/StateMachine.hs
+++ b/fs-sim/test/Test/System/FS/StateMachine.hs
@@ -95,7 +95,7 @@ import           Test.Tasty.QuickCheck
 import           System.FS.API (HasFS (..))
 import           System.FS.API.Types
 import           System.FS.IO
-import qualified System.IO.FS as F
+import qualified System.FS.IO.Internal as F
 
 import           Util.Condense
 


### PR DESCRIPTION
Modules that are required for `ioHasFS` should never be used by client code. For this reason, we move the relevant modules into an `Internal` hierarchy.