### PR TITLE
Move strict and lazy read/write operations into separate modules.

### DIFF
--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -8,6 +8,11 @@
   For this reason, we move the relevant modules into an `Internal` hierarchy.
   * Move the `System.IO.FS` module to `System.FS.IO.Internal`.
   * Move the `System.FS.Handle` module to `System.FS.IO.Internal.Handle`.
+* Move strict and lazy compound definitions for reading/writing bytes into separate modules `System.FS.API.Strict` and `System.FS.API.Lazy`. Both modules re-export `System.FS.API`.
+
+### Non-breaking
+
+* Re-export `System.FS.API.Types` from `System.FS.API`.
 
 ## 0.1.0.3 -- 2023-06-2
 

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -32,6 +32,8 @@ library
 
   exposed-modules:
     System.FS.API
+    System.FS.API.Lazy
+    System.FS.API.Strict
     System.FS.API.Types
     System.FS.CRC
     System.FS.IO

--- a/fs-api/src/System/FS/API.hs
+++ b/fs-api/src/System/FS/API.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DerivingVia         #-}
 {-# LANGUAGE GADTs               #-}
@@ -9,31 +8,24 @@
 
 -- | An abstract view over the filesystem.
 module System.FS.API (
-    Handle (..)
-  , HasFS (..)
-  , SomeHasFS (..)
+    -- * Record that abstracts over the filesystem
+    HasFS (..)
+    -- * Types
+  , module Types
+    -- * Opening and closing files
   , hClose'
-  , hGetAll
-  , hGetAllAt
-  , hGetExactly
-  , hGetExactlyAt
-  , hPut
-  , hPutAll
-  , hPutAllStrict
   , withFile
+    -- * SomeHasFS
+  , SomeHasFS (..)
   ) where
 
-import           Control.Monad (foldM)
 import           Control.Monad.Class.MonadThrow
 import qualified Data.ByteString as BS
-import           Data.ByteString.Builder (Builder)
-import qualified Data.ByteString.Builder as BS
-import qualified Data.ByteString.Lazy as BL
 import           Data.Int (Int64)
 import           Data.Set (Set)
 import           Data.Word
 
-import           System.FS.API.Types
+import           System.FS.API.Types as Types
 
 import           Util.CallStack
 
@@ -156,6 +148,10 @@ data HasFS m h = HasFS {
   , unsafeToFilePath         :: FsPath -> m FilePath
   }
 
+{-------------------------------------------------------------------------------
+  Opening and closing files
+-------------------------------------------------------------------------------}
+
 withFile :: (HasCallStack, MonadThrow m)
          => HasFS m h -> FsPath -> OpenMode -> (Handle h -> m a) -> m a
 withFile HasFS{..} fp openMode = bracket (hOpen fp openMode) hClose
@@ -169,137 +165,6 @@ hClose' HasFS { hClose, hIsOpen } h = do
       return True
     else
       return False
-
--- | Makes sure it reads all requested bytes.
--- If eof is found before all bytes are read, it throws an exception.
-hGetExactly :: forall m h. (HasCallStack, MonadThrow m)
-            => HasFS m h
-            -> Handle h
-            -> Word64
-            -> m BL.ByteString
-hGetExactly hasFS h n = go n []
-  where
-    go :: Word64 -> [BS.ByteString] -> m BL.ByteString
-    go remainingBytes acc
-      | remainingBytes == 0 = return $ BL.fromChunks $ reverse acc
-      | otherwise           = do
-        bs <- hGetSome hasFS h remainingBytes
-        if BS.null bs then
-          throwIO FsError {
-              fsErrorType   = FsReachedEOF
-            , fsErrorPath   = mkFsErrorPath hasFS $ handlePath h
-            , fsErrorString = "hGetExactly found eof before reading " ++ show n ++ " bytes"
-            , fsErrorNo     = Nothing
-            , fsErrorStack  = prettyCallStack
-            , fsLimitation  = False
-            }
-        -- We know the length <= remainingBytes, so this can't underflow
-        else go (remainingBytes - fromIntegral (BS.length bs)) (bs : acc)
-
--- | Like 'hGetExactly', but is thread safe since it does not change or depend
--- on the file offset. @pread@ syscall is used internally.
-hGetExactlyAt :: forall m h. (HasCallStack, MonadThrow m)
-              => HasFS m h
-              -> Handle h
-              -> Word64    -- ^ The number of bytes to read.
-              -> AbsOffset -- ^ The offset at which to read.
-              -> m BL.ByteString
-hGetExactlyAt hasFS h n offset = go n offset []
-  where
-    go :: Word64 -> AbsOffset -> [BS.ByteString] -> m BL.ByteString
-    go remainingBytes currentOffset acc
-      | remainingBytes == 0 = return $ BL.fromChunks $ reverse acc
-      | otherwise           = do
-        bs <- hGetSomeAt hasFS h remainingBytes currentOffset
-        let readBytes = BS.length bs
-        if BS.null bs then
-          throwIO FsError {
-              fsErrorType   = FsReachedEOF
-            , fsErrorPath   = mkFsErrorPath hasFS $ handlePath h
-            , fsErrorString = "hGetExactlyAt found eof before reading " ++ show n ++ " bytes"
-            , fsErrorNo     = Nothing
-            , fsErrorStack  = prettyCallStack
-            , fsLimitation  = False
-            }
-        -- We know the length <= remainingBytes, so this can't underflow.
-        else go (remainingBytes - fromIntegral readBytes)
-                (currentOffset + fromIntegral readBytes)
-                (bs : acc)
-
--- | Read all the data from the given file handle 64kB at a time.
---
--- Stops when EOF is reached.
-hGetAll :: Monad m => HasFS m h -> Handle h -> m BL.ByteString
-hGetAll HasFS{..} hnd = go mempty
-  where
-    bufferSize = 64 * 1024
-    go acc = do
-      chunk <- hGetSome hnd bufferSize
-      let acc' = chunk : acc
-      if BS.null chunk
-        then return $ BL.fromChunks $ reverse acc'
-        else go acc'
-
--- | Like 'hGetAll', but is thread safe since it does not change or depend
--- on the file offset. @pread@ syscall is used internally.
-hGetAllAt :: Monad m
-          => HasFS m h
-          -> Handle h
-          -> AbsOffset -- ^ The offset at which to read.
-          -> m BL.ByteString
-hGetAllAt HasFS{..} hnd = go mempty
-  where
-    bufferSize = 64 * 1024
-    go acc offset = do
-      chunk <- hGetSomeAt hnd bufferSize offset
-      let acc' = chunk : acc
-      if BS.null chunk
-        then return $ BL.fromChunks $ reverse acc'
-        else go acc' (offset + fromIntegral (BS.length chunk))
-
--- | This function makes sure that the whole 'BS.ByteString' is written.
-hPutAllStrict :: forall m h
-              .  (HasCallStack, Monad m)
-              => HasFS m h
-              -> Handle h
-              -> BS.ByteString
-              -> m Word64
-hPutAllStrict hasFS h = go 0
-  where
-    go :: Word64 -> BS.ByteString -> m Word64
-    go !written bs = do
-      n <- hPutSome hasFS h bs
-      let bs'      = BS.drop (fromIntegral n) bs
-          written' = written + n
-      if BS.null bs'
-        then return written'
-        else go written' bs'
-
--- | This function makes sure that the whole 'BL.ByteString' is written.
-hPutAll :: forall m h
-        .  (HasCallStack, Monad m)
-        => HasFS m h
-        -> Handle h
-        -> BL.ByteString
-        -> m Word64
-hPutAll hasFS h = foldM putChunk 0 . BL.toChunks
-  where
-    putChunk :: Word64 -> BS.ByteString -> m Word64
-    putChunk written chunk = do
-      written' <- hPutAllStrict hasFS h chunk
-      return $! written + written'
-
--- | This function makes sure that the whole 'Builder' is written.
---
--- The chunk size of the resulting 'BL.ByteString' determines how much memory
--- will be used while writing to the handle.
-hPut :: forall m h
-     .  (HasCallStack, Monad m)
-     => HasFS m h
-     -> Handle h
-     -> Builder
-     -> m Word64
-hPut hasFS g = hPutAll hasFS g . BS.toLazyByteString
 
 {-------------------------------------------------------------------------------
   SomeHasFS

--- a/fs-api/src/System/FS/API/Lazy.hs
+++ b/fs-api/src/System/FS/API/Lazy.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module System.FS.API.Lazy (
+    -- * API
+    module API
+    -- * Lazy functions
+  , hGetAll
+  , hGetAllAt
+  , hGetExactly
+  , hGetExactlyAt
+  , hPut
+  , hPutAll
+  ) where
+
+import           Control.Monad (foldM)
+import           Control.Monad.Class.MonadThrow (MonadThrow (throwIO))
+import qualified Data.ByteString as BS
+import           Data.ByteString.Builder (Builder)
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Lazy as BL
+import           Data.Word (Word64)
+import           System.FS.API as API
+import           System.FS.API.Strict
+import           Util.CallStack (HasCallStack, prettyCallStack)
+
+-- | Makes sure it reads all requested bytes.
+-- If eof is found before all bytes are read, it throws an exception.
+hGetExactly :: forall m h. (HasCallStack, MonadThrow m)
+            => HasFS m h
+            -> Handle h
+            -> Word64
+            -> m BL.ByteString
+hGetExactly hasFS h n = go n []
+  where
+    go :: Word64 -> [BS.ByteString] -> m BL.ByteString
+    go remainingBytes acc
+      | remainingBytes == 0 = return $ BL.fromChunks $ reverse acc
+      | otherwise           = do
+        bs <- hGetSome hasFS h remainingBytes
+        if BS.null bs then
+          throwIO FsError {
+              fsErrorType   = FsReachedEOF
+            , fsErrorPath   = mkFsErrorPath hasFS $ handlePath h
+            , fsErrorString = "hGetExactly found eof before reading " ++ show n ++ " bytes"
+            , fsErrorNo     = Nothing
+            , fsErrorStack  = prettyCallStack
+            , fsLimitation  = False
+            }
+        -- We know the length <= remainingBytes, so this can't underflow
+        else go (remainingBytes - fromIntegral (BS.length bs)) (bs : acc)
+
+-- | Like 'hGetExactly', but is thread safe since it does not change or depend
+-- on the file offset. @pread@ syscall is used internally.
+hGetExactlyAt :: forall m h. (HasCallStack, MonadThrow m)
+              => HasFS m h
+              -> Handle h
+              -> Word64    -- ^ The number of bytes to read.
+              -> AbsOffset -- ^ The offset at which to read.
+              -> m BL.ByteString
+hGetExactlyAt hasFS h n offset = go n offset []
+  where
+    go :: Word64 -> AbsOffset -> [BS.ByteString] -> m BL.ByteString
+    go remainingBytes currentOffset acc
+      | remainingBytes == 0 = return $ BL.fromChunks $ reverse acc
+      | otherwise           = do
+        bs <- hGetSomeAt hasFS h remainingBytes currentOffset
+        let readBytes = BS.length bs
+        if BS.null bs then
+          throwIO FsError {
+              fsErrorType   = FsReachedEOF
+            , fsErrorPath   = mkFsErrorPath hasFS $ handlePath h
+            , fsErrorString = "hGetExactlyAt found eof before reading " ++ show n ++ " bytes"
+            , fsErrorNo     = Nothing
+            , fsErrorStack  = prettyCallStack
+            , fsLimitation  = False
+            }
+        -- We know the length <= remainingBytes, so this can't underflow.
+        else go (remainingBytes - fromIntegral readBytes)
+                (currentOffset + fromIntegral readBytes)
+                (bs : acc)
+
+-- | Read all the data from the given file handle 64kB at a time.
+--
+-- Stops when EOF is reached.
+hGetAll :: Monad m => HasFS m h -> Handle h -> m BL.ByteString
+hGetAll HasFS{..} hnd = go mempty
+  where
+    bufferSize = 64 * 1024
+    go acc = do
+      chunk <- hGetSome hnd bufferSize
+      let acc' = chunk : acc
+      if BS.null chunk
+        then return $ BL.fromChunks $ reverse acc'
+        else go acc'
+
+-- | Like 'hGetAll', but is thread safe since it does not change or depend
+-- on the file offset. @pread@ syscall is used internally.
+hGetAllAt :: Monad m
+          => HasFS m h
+          -> Handle h
+          -> AbsOffset -- ^ The offset at which to read.
+          -> m BL.ByteString
+hGetAllAt HasFS{..} hnd = go mempty
+  where
+    bufferSize = 64 * 1024
+    go acc offset = do
+      chunk <- hGetSomeAt hnd bufferSize offset
+      let acc' = chunk : acc
+      if BS.null chunk
+        then return $ BL.fromChunks $ reverse acc'
+        else go acc' (offset + fromIntegral (BS.length chunk))
+
+-- | This function makes sure that the whole 'BL.ByteString' is written.
+hPutAll :: forall m h
+        .  (HasCallStack, Monad m)
+        => HasFS m h
+        -> Handle h
+        -> BL.ByteString
+        -> m Word64
+hPutAll hasFS h = foldM putChunk 0 . BL.toChunks
+  where
+    putChunk :: Word64 -> BS.ByteString -> m Word64
+    putChunk written chunk = do
+      written' <- hPutAllStrict hasFS h chunk
+      return $! written + written'
+
+-- | This function makes sure that the whole 'Builder' is written.
+--
+-- The chunk size of the resulting 'BL.ByteString' determines how much memory
+-- will be used while writing to the handle.
+hPut :: forall m h
+     .  (HasCallStack, Monad m)
+     => HasFS m h
+     -> Handle h
+     -> Builder
+     -> m Word64
+hPut hasFS g = hPutAll hasFS g . BS.toLazyByteString

--- a/fs-api/src/System/FS/API/Strict.hs
+++ b/fs-api/src/System/FS/API/Strict.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module System.FS.API.Strict (
+    -- * API
+    module API
+    -- * Strict functions
+  , hPutAllStrict
+  ) where
+
+import qualified Data.ByteString as BS
+import           Data.Word
+import           System.FS.API as API
+import           Util.CallStack
+
+-- | This function makes sure that the whole 'BS.ByteString' is written.
+hPutAllStrict :: forall m h
+              .  (HasCallStack, Monad m)
+              => HasFS m h
+              -> Handle h
+              -> BS.ByteString
+              -> m Word64
+hPutAllStrict hasFS h = go 0
+  where
+    go :: Word64 -> BS.ByteString -> m Word64
+    go !written bs = do
+      n <- hPutSome hasFS h bs
+      let bs'      = BS.drop (fromIntegral n) bs
+          written' = written + n
+      if BS.null bs'
+        then return written'
+        else go written' bs'

--- a/fs-api/src/System/FS/CRC.hs
+++ b/fs-api/src/System/FS/CRC.hs
@@ -26,8 +26,8 @@ import           Data.Word
 import           Foreign.Storable (Storable)
 import           GHC.Generics (Generic)
 import           GHC.Stack
-import           System.FS.API
-import           System.FS.API.Types (AbsOffset (..))
+import           System.FS.API.Lazy
+import           System.FS.API.Strict
 
 {-------------------------------------------------------------------------------
   Wrap functionality from digest

--- a/fs-api/src/System/FS/IO.hs
+++ b/fs-api/src/System/FS/IO.hs
@@ -14,7 +14,6 @@ import           Foreign (castPtr)
 import           GHC.Stack
 import qualified System.Directory as Dir
 import           System.FS.API
-import           System.FS.API.Types
 import qualified System.FS.IO.Internal as F
 import qualified System.FS.IO.Internal.Handle as H
 

--- a/fs-sim/src/System/FS/Sim/Error.hs
+++ b/fs-sim/src/System/FS/Sim/Error.hs
@@ -61,7 +61,6 @@ import           Test.QuickCheck (ASCIIString (..), Arbitrary (..), Gen,
 import           Util.CallStack
 
 import           System.FS.API
-import           System.FS.API.Types
 
 import           System.FS.Sim.MockFS (HandleMock, MockFS)
 import qualified System.FS.Sim.STM as Sim

--- a/fs-sim/src/System/FS/Sim/Pure.hs
+++ b/fs-sim/src/System/FS/Sim/Pure.hs
@@ -11,7 +11,6 @@ import           Control.Monad.Except
 import           Control.Monad.State
 
 import           System.FS.API
-import           System.FS.API.Types
 
 import qualified System.FS.Sim.MockFS as Mock
 import           System.FS.Sim.MockFS (MockFS)

--- a/fs-sim/src/System/FS/Sim/STM.hs
+++ b/fs-sim/src/System/FS/Sim/STM.hs
@@ -12,7 +12,6 @@ import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           System.FS.API
-import           System.FS.API.Types
 
 import qualified System.FS.Sim.MockFS as Mock
 import           System.FS.Sim.MockFS (HandleMock, MockFS)

--- a/fs-sim/test/Test/System/FS/StateMachine.hs
+++ b/fs-sim/test/Test/System/FS/StateMachine.hs
@@ -92,8 +92,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck
 
-import           System.FS.API (HasFS (..))
-import           System.FS.API.Types
+import           System.FS.API
 import           System.FS.IO
 import qualified System.FS.IO.Internal as F
 


### PR DESCRIPTION
Additional change: the `System.FS.API` module now re-exports the `System.FS.API.Types` module. This may cause `redundant import` warnings for downstream users, but we don't consider that a breaking change.