### PR TITLE
Bump `fs-sim-0.2.1.0` to `fs-sim-0.3.0.0`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,12 +56,8 @@ like `A.B.C.D`.
 * `D` is the *patch* version number. A bump indicates a small, non-breaking
   patch.
 
-To prevent accidental breakage for downstream packages, `fs-api` and `fs-sim`
-should be released in lockstep with respect to major version bumps. This means
-that a major version bump for `fs-api` should result in a major version bump for
-`fs-sim`, and vice versa. `fs-api` and `fs-sim` can be released invidivually
-when only minor or patch version numbers are bumped. Preferably, `fs-sim-x.y.*`
-should have a caret bound on `fs-api-x.y.*`, i.e., `^>= fs-api-x.y`
-
-NOTE: before `fs-sim-0.3.*` and `fs-api-0.3.*`, both packages were not released
-in lockstep.
+As a general rule of thumb, tightening a dependency bound should result in a
+major version bump if the tighter bound is reasonably expected to break
+dependent packages. Otherwise, tightening and/or loosening a dependency bound
+should result in a patch-level (or someimes minor-level) version bump, and
+possibly a revision in CHaP.

--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Revision history for fs-sim
 
-## 0.2.1.0 -- 2023-06-02
+## 0.3.0.0 -- 2023-08-01
 
-### Non-breaking
+### Breaking
 
 * Build with `fs-api ^>=0.2`.
 

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            fs-sim
-version:         0.2.1.0
+version:         0.3.0.0
 synopsis:        Simulated file systems
 description:     Simulated file systems.
 license:         Apache-2.0


### PR DESCRIPTION
After some consideration, it would make more sense to give `fs-sim` a major version bump because `fs-api` got a major version bump that broke the build of `fs-sim`.