### PR TITLE
Update Haskell setup in CI because the current action is deprecated

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   # Sources
-  # * https://github.com/haskell/actions/tree/v2/setup#model-cabal-workflow-with-caching
+  # * https://github.com/haskell-actions/setup#model-cabal-workflow-with-caching
   # * https://haskell-haddock.readthedocs.io/en/latest/multi-components.html
   # * https://github.com/input-output-hk/ouroboros-consensus/blob/b0a6f9148d3c3783cb9980c756162426f8066471/.github/workflows/ci.yml
   # * https://github.com/input-output-hk/ouroboros-consensus/blob/4ff9aa5596598bb3681864b830c8a33e294d9bfe/scripts/docs/haddocks.sh
@@ -30,7 +30,7 @@ jobs:
 
     env:
       ghc: "9.2.8"
-      cabal: "3.10.1.0"
+      cabal: "3.10.2.0"
       os: ubuntu-latest"
 
     steps:
@@ -39,7 +39,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskel-actions/setup@v2
       with:
         ghc-version: ${{ env.ghc }}
         cabal-version: ${{ env.cabal }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -92,7 +92,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -151,7 +151,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -205,7 +205,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}


### PR DESCRIPTION
See https://github.com/haskell/actions/pull/301