### PR TITLE
Re-enable QSM tests for all distributions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ env.ghc }}
         cabal-version: ${{ env.cabal }}

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for fs-api
 
+## next release -- ????-??-??
+
+### Patch
+
+* Make internal error comparison function more lenient on MacOS systems.
+
 ## 0.2.0.1 -- 2023-10-30
 
 ### Patch

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -23,13 +23,6 @@ source-repository head
 
 library
   hs-source-dirs:   src
-
-  if os(windows)
-    hs-source-dirs: src-win32
-
-  else
-    hs-source-dirs: src-unix
-
   exposed-modules:
     System.FS.API
     System.FS.API.Lazy
@@ -55,12 +48,22 @@ library
     , text        >=1.2  && <2.2
 
   if os(windows)
-    build-depends: Win32 >=2.6.1.0
+    hs-source-dirs: src-win32
+    build-depends:  Win32 >=2.6.1.0
 
   else
+    hs-source-dirs:  src-unix
     build-depends:
       , unix
       , unix-bytestring  >=0.4.0
+
+    exposed-modules: System.FS.IO.Internal.Error
+
+    if os(linux)
+      hs-source-dirs: src-linux
+
+    else
+      hs-source-dirs: src-macos
 
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns

--- a/fs-api/src-linux/System/FS/IO/Internal/Error.hs
+++ b/fs-api/src-linux/System/FS/IO/Internal/Error.hs
@@ -1,0 +1,7 @@
+module System.FS.IO.Internal.Error (sameError) where
+
+import           System.FS.API.Types (FsError, sameFsError)
+
+sameError :: FsError -> FsError -> Bool
+sameError = sameFsError
+

--- a/fs-api/src-macos/System/FS/IO/Internal/Error.hs
+++ b/fs-api/src-macos/System/FS/IO/Internal/Error.hs
@@ -1,0 +1,17 @@
+module System.FS.IO.Internal.Error (sameError) where
+
+import           System.FS.API.Types (FsError (..), FsErrorType (..),
+                     sameFsError)
+
+-- Check default implementation first using 'sameFsError', and otherwise permit
+-- some combinations of error types that are not structurally equal.
+sameError :: FsError -> FsError -> Bool
+sameError e1 e2 = sameFsError e1 e2
+               || (fsErrorPath e1 == fsErrorPath e2
+               && permitted (fsErrorType e1) (fsErrorType e2))
+  where
+    -- error types that are permitted to differ for technical reasons
+    permitted ty1 ty2 = case (ty1, ty2) of
+      (FsInsufficientPermissions  , FsResourceInappropriateType) -> True
+      (FsResourceInappropriateType, FsInsufficientPermissions  ) -> True
+      (_                          , _                          ) -> False

--- a/fs-api/src-unix/System/FS/IO/Internal.hs
+++ b/fs-api/src-unix/System/FS/IO/Internal.hs
@@ -24,8 +24,9 @@ import qualified Data.ByteString.Internal as Internal
 import           Data.Int (Int64)
 import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Ptr)
-import           System.FS.API.Types (AllowExisting (..), FsError,
-                     OpenMode (..), SeekMode (..), sameFsError)
+import           System.FS.API.Types (AllowExisting (..), OpenMode (..),
+                     SeekMode (..))
+import           System.FS.IO.Internal.Error (sameError)
 import           System.FS.IO.Internal.Handle
 import qualified System.Posix as Posix
 import           System.Posix (Fd)
@@ -152,6 +153,3 @@ close h = closeHandleOS h Posix.closeFd
 getSize :: FHandle -> IO Word64
 getSize h = withOpenHandle "getSize" h $ \fd ->
      fromIntegral . Posix.fileSize <$> Posix.getFdStatus fd
-
-sameError :: FsError -> FsError -> Bool
-sameError = sameFsError

--- a/fs-sim/test/Main.hs
+++ b/fs-sim/test/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module Main (main) where
 
 import           System.IO.Temp (withSystemTempDirectory)
@@ -14,18 +12,9 @@ main = withSystemTempDirectory "fs-sim-test" $ \tmpDir ->
   defaultMain $
     testGroup "Test" [
         testGroup "System" [
-            -- TODO: The FS tests fail for darwin on CI, see #532. So, they are
-            -- disabled for now, but should be enabled once #532 is resolved.
-            testGroup "FS" $
-              [ Test.System.FS.StateMachine.tests tmpDir | not darwin] <>
-              [ Test.System.FS.Sim.FsTree.tests
+            testGroup "FS" [
+                Test.System.FS.StateMachine.tests tmpDir
+              , Test.System.FS.Sim.FsTree.tests
               ]
           ]
       ]
-
-darwin :: Bool
-#ifdef darwin_HOST_OS
-darwin = True
-#else
-darwin = False
-#endif


### PR DESCRIPTION
As a "temporary" fix for fs-sim#45, we make the implementation of
`sameError` more lenient on MacOS systems. This will possibly
be revisited in the future, but for now it should enable running
the `q-s-m` tests on all distributions again.