### PR TITLE
Fix broken Haddock

### DIFF
--- a/fs-api/src/System/FS/API.hs
+++ b/fs-api/src/System/FS/API.hs
@@ -67,7 +67,8 @@ data HasFS m h = HasFS {
     -- will always return at least 1 byte, as returning 0 bytes would mean
     -- that we have reached EOF.
     --
-    -- Postcondition: the length of the returned bytestring <= @n@ and >= 0.
+    -- Postcondition: for the length of the returned bytestring @bs@ we have
+    -- @length bs >= 0@ and @length bs <= n@.
   , hGetSome                 :: HasCallStack => Handle h -> Word64 -> m BS.ByteString
 
     -- | Same as 'hGetSome', but does not affect the file offset. An additional argument
@@ -89,8 +90,8 @@ data HasFS m h = HasFS {
     --
     -- If nothing can be written at all, an exception will be thrown.
     --
-    -- Postcondition: the return value <= @l@ and > 0, unless the given
-    -- bytestring is empty, in which case the return value can be 0.
+    -- Postcondition: the return value @n@ is @n > 0@ and @n <= l@, unless the
+    -- given bytestring is empty, in which case @n@ can be 0.
   , hPutSome                 :: HasCallStack => Handle h -> BS.ByteString -> m Word64
 
     -- | Truncate the file to the specified size

--- a/fs-api/src/System/FS/API/Types.hs
+++ b/fs-api/src/System/FS/API/Types.hs
@@ -66,7 +66,7 @@ import           Util.Condense
   Modes
 -------------------------------------------------------------------------------}
 
--- | How to 'hOpen' a new file.
+-- | How to 'System.FS.API.hOpen' a new file.
 data OpenMode
   = ReadMode
   | WriteMode     AllowExisting
@@ -74,7 +74,7 @@ data OpenMode
   | ReadWriteMode AllowExisting
   deriving (Eq, Show)
 
--- | When 'hOpen'ing a file:
+-- | When opening a file:
 data AllowExisting
   = AllowExisting
     -- ^ The file may already exist. If it does, it is reopened. If it
@@ -299,7 +299,7 @@ ioToFsError fep ioErr = FsError
 --
 -- Note that we don't always use the classification made by
 -- 'Foreign.C.Error.errnoToIOError' (also see 'System.IO.Error') because it
--- combines some errors into one 'IOErrorType', e.g., @EMFILE@ (too many open
+-- combines some errors into one 'IO.IOErrorType', e.g., @EMFILE@ (too many open
 -- files) and @ENOSPC@ (no space left on device) both result in
 -- 'ResourceExhausted' while we want to keep them separate. For this reason,
 -- we do a classification of our own based on the @errno@ while sometimes


### PR DESCRIPTION
I just noticed some broken Haddock (`>=` outside code, see postconditions in the image) and fixed it. 

<details>

<summary>image of broken docs</summary>

![Screenshot from 2024-02-12 16-58-52](https://github.com/input-output-hk/fs-sim/assets/8507844/9de57387-4611-4620-a911-6ac1d8d2a9c6)

</details>

There are also quite a few warnings for linked identifiers being out of scope, but since they fall back quite gracefully it's probably not worth hunting them all down.