### PR TITLE
`IOHasBufFS` interface for I/O using user-supplied buffers

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -21,7 +21,7 @@ steps:
   #
   #     # Should export lists be sorted?  Sorting is only performed within the
   #     # export section, as delineated by Haddock comments.
-      sort: true
+      sort: false
   #
   #     # See `separate_lists` for the `imports` step.
       separate_lists: true

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## next release -- ????-??-??
 
+### Breaking
+
+* New `primitive ^>=0.9` dependency
+
+### Non-breaking
+
+* Add new `HasBufFS` interface for performing I/O using buffers. Note that it is
+  likely that this interfaced is unified with the `HasFS` interface in the
+  future.
+* Add compound functions, built from primitives in `HasBufFS`: `hGetAllAt`,
+  `hGetBufExactly`, `hPutBufExactly`, `hGetBufExactlyAt` and `hPutBufExactlyAt`
+* Provide an instantiation of the `HasBufFS` interface for `IO`.
+
 ### Patch
 
 * Make internal error comparison function more lenient on MacOS systems.

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -10,7 +10,7 @@ license-files:
 
 copyright:       2019-2023 Input Output Global Inc (IOG)
 author:          IOG Engineering Team
-maintainer:      operations@iohk.io, Joris Dral
+maintainer:      operations@iohk.io, Joris Dral (joris@well-typed.com)
 category:        System
 build-type:      Simple
 extra-doc-files: CHANGELOG.md
@@ -45,6 +45,7 @@ library
     , directory   >=1.3  && <1.4
     , filepath    >=1.4  && <1.5
     , io-classes  >=0.3  && <1.5
+    , primitive   ^>=0.9
     , text        >=1.2  && <2.2
 
   if os(windows)
@@ -69,3 +70,24 @@ library
     -Wall -Wcompat -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wpartial-fields -Widentities
     -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+
+test-suite fs-api-test
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  other-modules:    Test.System.FS.IO
+  default-language: Haskell2010
+  build-depends:
+    , base
+    , bytestring
+    , fs-api
+    , primitive
+    , tasty
+    , tasty-quickcheck
+    , temporary
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -fno-ignore-asserts

--- a/fs-api/test/Main.hs
+++ b/fs-api/test/Main.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import           Test.System.FS.IO
+import           Test.Tasty
+
+main :: IO ()
+main = defaultMain $ testGroup "fs-api-test" [
+      Test.System.FS.IO.tests
+    ]

--- a/fs-api/test/Test/System/FS/IO.hs
+++ b/fs-api/test/Test/System/FS/IO.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.System.FS.IO (tests) where
+
+import           Control.Monad.Primitive
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short.Internal as SBS
+import           Data.Primitive.ByteArray
+import           Prelude hiding (read)
+import qualified System.FS.API as FS
+import qualified System.FS.IO as IO
+import           System.IO.Temp
+import           System.Posix.Types (ByteCount)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.System.FS.IO" [
+      testProperty "prop_roundtrip_hPutGetBufSome"
+        prop_roundtrip_hPutGetBufSome
+    , testProperty "prop_roundtrip_hPutGetBufSomeAt"
+        prop_roundtrip_hPutGetBufSomeAt
+    , testProperty "prop_roundtrip_hPutGetBufExactly"
+        prop_roundtrip_hPutGetBufExactly
+    , testProperty "prop_roundtrip_hPutGetBufExactlyAt"
+        prop_roundtrip_hPutGetBufExactlyAt
+    ]
+
+instance Arbitrary ByteString where
+  arbitrary = BS.pack <$> arbitrary
+  shrink = fmap BS.pack . shrink . BS.unpack
+
+instance Arbitrary FS.AbsOffset where
+  arbitrary = FS.AbsOffset . getSmall <$> arbitrary
+  shrink (FS.AbsOffset x) = FS.AbsOffset <$> shrink x
+
+fromByteString :: PrimMonad m => ByteString -> m (MutableByteArray (PrimState m))
+fromByteString bs = thawByteArray (ByteArray ba) 0 (SBS.length sbs)
+  where !sbs@(SBS.SBS ba) = SBS.toShort bs
+
+toByteString :: PrimMonad m => Int -> MutableByteArray (PrimState m) -> m ByteString
+toByteString n mba = freezeByteArray mba 0 n >>= \(ByteArray ba) -> pure (SBS.fromShort $ SBS.SBS ba)
+
+-- | A write-then-read roundtrip test for buffered I\/O in 'IO'.
+--
+-- The 'ByteString'\'s internal pointer doubles as the buffer used for the I\/O
+-- operations, and we only write/read a prefix of the bytestring. This does not
+-- test what happens if we try to write/read more bytes than fits in the buffer,
+-- because the behaviour is then undefined.
+prop_roundtrip_hPutGetBufSome ::
+     ByteString
+  -> Small ByteCount -- ^ Prefix length
+  -> Property
+prop_roundtrip_hPutGetBufSome bs (Small c) =
+  BS.length bs >= fromIntegral c ==>
+  ioProperty $ withSystemTempDirectory "prop_roundtrip_hPutGetBufSome" $ \dirPath -> do
+    let hfs  = IO.ioHasFS (FS.MountPoint dirPath)
+        hbfs = IO.ioHasBufFS (FS.MountPoint dirPath)
+
+    FS.withFile hfs (FS.mkFsPath ["temp"]) (FS.WriteMode FS.MustBeNew) $ \h -> do
+      putBuf <- fromByteString bs
+      m <- FS.hPutBufSome hbfs h putBuf 0 c
+      let writeTest = counterexample "wrote too many bytes" ((if c > 0 then 1 .<= m else property True) .&&. m .<= c)
+      FS.hSeek hfs h FS.AbsoluteSeek 0
+      getBuf <- newPinnedByteArray (fromIntegral m)
+      o <- FS.hGetBufSome hbfs h getBuf 0 m
+      let readTest = counterexample "read too many bytes"   ((if c > 0 then 1 .<= o else property True) .&&. o .<= m)
+      bs' <- toByteString (fromIntegral o) getBuf
+      let cmpTest = counterexample "(prefix of) input and output bytestring do not match"
+                  $ BS.take (fromIntegral o) bs === bs'
+      pure (writeTest .&&. readTest .&&. cmpTest)
+
+-- | Like 'prop_roundtrip_hPutGetBufSome', but reading and writing at a specified offset.
+prop_roundtrip_hPutGetBufSomeAt ::
+     ByteString
+  -> Small ByteCount -- ^ Prefix length
+  -> FS.AbsOffset
+  -> Property
+prop_roundtrip_hPutGetBufSomeAt bs (Small c) off =
+  BS.length bs >= fromIntegral c ==>
+  ioProperty $ withSystemTempDirectory "prop_roundtrip_hPutGetBufSomeAt" $ \dirPath -> do
+    let hfs  = IO.ioHasFS (FS.MountPoint dirPath)
+        hbfs = IO.ioHasBufFS (FS.MountPoint dirPath)
+
+    FS.withFile hfs (FS.mkFsPath ["temp"]) (FS.WriteMode FS.MustBeNew) $ \h -> do
+      putBuf <- fromByteString bs
+      m <- FS.hPutBufSomeAt hbfs h putBuf 0 c off
+      let writeTest = counterexample "wrote too many bytes" ((if c > 0 then 1 .<= m else property True) .&&. m .<= c)
+      getBuf <- newPinnedByteArray (fromIntegral m)
+      o <- FS.hGetBufSomeAt hbfs h getBuf 0 m off
+      let readTest = counterexample "read too many bytes"   ((if c > 0 then 1 .<= o else property True) .&&. o .<= m)
+      bs' <- toByteString (fromIntegral o) getBuf
+      let cmpTest = counterexample "(prefix of) input and output bytestring do not match"
+                  $ BS.take (fromIntegral o) bs === bs'
+      pure (writeTest .&&. readTest .&&. cmpTest)
+
+-- | Like 'prop_roundtrip_hPutGetBufSome', but ensuring that all bytes are
+-- written/read.
+prop_roundtrip_hPutGetBufExactly ::
+     ByteString
+  -> Small ByteCount -- ^ Prefix length
+  -> Property
+prop_roundtrip_hPutGetBufExactly bs (Small c) =
+  BS.length bs >= fromIntegral c ==>
+  ioProperty $ withSystemTempDirectory "prop_roundtrip_hPutGetBufExactly" $ \dirPath -> do
+    let hfs  = IO.ioHasFS (FS.MountPoint dirPath)
+        hbfs = IO.ioHasBufFS (FS.MountPoint dirPath)
+
+    FS.withFile hfs (FS.mkFsPath ["temp"]) (FS.WriteMode FS.MustBeNew) $ \h -> do
+      putBuf <- fromByteString bs
+      m <- FS.hPutBufExactly hbfs h putBuf 0 c
+      let writeTest = counterexample "wrote too few bytes" (m === c)
+      FS.hSeek hfs h FS.AbsoluteSeek 0
+      getBuf <- newPinnedByteArray (fromIntegral c)
+      o <- FS.hGetBufExactly hfs hbfs h getBuf 0 c
+      let readTest = counterexample "read too few byes"    (o === c)
+      bs' <- toByteString (fromIntegral c) getBuf
+      let cmpTest = counterexample "input and output bytestring do not match"
+                  $ BS.take (fromIntegral c) bs === BS.take (fromIntegral c) bs'
+      pure (writeTest .&&. readTest .&&. cmpTest)
+
+-- | Like 'prop_roundtrip_hPutGetBufSome', but reading and writing at a
+-- specified offset, and ensuring that all bytes are written/read.
+prop_roundtrip_hPutGetBufExactlyAt ::
+     ByteString
+  -> Small ByteCount -- ^ Prefix length
+  -> FS.AbsOffset
+  -> Property
+prop_roundtrip_hPutGetBufExactlyAt bs (Small c) off =
+  BS.length bs >= fromIntegral c ==>
+  ioProperty $ withSystemTempDirectory "prop_roundtrip_hPutGetBufExactlyAt" $ \dirPath -> do
+    let hfs  = IO.ioHasFS (FS.MountPoint dirPath)
+        hbfs = IO.ioHasBufFS (FS.MountPoint dirPath)
+
+    FS.withFile hfs (FS.mkFsPath ["temp"]) (FS.WriteMode FS.MustBeNew) $ \h -> do
+      putBuf <- fromByteString bs
+      m <- FS.hPutBufExactlyAt hbfs h putBuf 0 c off
+      let writeTest = counterexample "wrote too few bytes" (m === c)
+      getBuf <- newPinnedByteArray (fromIntegral c)
+      o <- FS.hGetBufExactlyAt hfs hbfs h getBuf 0 c off
+      let readTest = counterexample "read too few byes"    (o === c)
+      bs' <- toByteString (fromIntegral c) getBuf
+      let cmpTest = counterexample "input and output bytestring do not match"
+                  $ BS.take (fromIntegral c) bs === BS.take (fromIntegral c) bs'
+      pure (writeTest .&&. readTest .&&. cmpTest)
+
+infix 4 .<=
+
+(.<=) :: (Ord a, Show a) => a -> a -> Property
+x .<= y = counterexample (show x ++ interpret res ++ show y) res
+  where
+    res             = x <= y
+    interpret True  = " <= "
+    interpret False = " > "


### PR DESCRIPTION
We require this interface in https://github.com/input-output-hk/lsm-tree, because going through `ByteString` is incompatible with the code in some places, and it's costly to allocate intermediate `ByteString`s instead of moving around bytes from/to `Ptr`s (and `ByteArray`s or `MutableByteArray`s)

Two notes:
* It's a separated interface from `HasFS` (for now), since I don't want to break downstream code yet.
* The interface is not yet simulated and extensively tested using state-machine tests in `fs-sim`, but will be after a future PR that I'm already working on. I'm currently hunting a persistent bug in the pure model used for the state-machine tests. For now, I've included a couple of simple round-trip tests that exercise the new functions