### PR TITLE
New `hTell` function for requesting the current absolute file offset

### DIFF
--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for fs-api
 
+## next release -- ????-??-??
+
+### Breaking
+
+* Add `hTell` function to `HasFS`, which returns the absolute file offset that
+  is stored in a file handle.
+
 ## 0.2.0.1 -- 2023-10-30
 
 ### Patch

--- a/fs-api/src-unix/System/FS/IO/Internal.hs
+++ b/fs-api/src-unix/System/FS/IO/Internal.hs
@@ -12,6 +12,7 @@ module System.FS.IO.Internal (
   , read
   , sameError
   , seek
+  , tell
   , truncate
   , write
   ) where
@@ -28,7 +29,7 @@ import           System.FS.API.Types (AllowExisting (..), FsError,
                      OpenMode (..), SeekMode (..), sameFsError)
 import           System.FS.IO.Internal.Handle
 import qualified System.Posix as Posix
-import           System.Posix (Fd)
+import           System.Posix (Fd (..))
 import           System.Posix.IO.ByteString.Ext (fdPreadBuf)
 
 type FHandle = HandleOS Fd
@@ -122,6 +123,11 @@ write h data' bytes = withOpenHandle "write" h $ \fd ->
 seek :: FHandle -> SeekMode -> Int64 -> IO ()
 seek h seekMode offset = withOpenHandle "seek" h $ \fd ->
     void $ Posix.fdSeek fd seekMode (fromIntegral offset)
+
+-- | Request the absolute file offset stored in the handle
+tell :: FHandle -> IO Word64
+tell h = withOpenHandle "tell" h $ \fd ->
+    fromIntegral <$> Posix.fdSeek fd RelativeSeek 0
 
 -- | Reads a given number of bytes from the input 'FHandle'.
 read :: FHandle -> Word64 -> IO ByteString

--- a/fs-api/src-win32/System/FS/IO/Internal.hs
+++ b/fs-api/src-win32/System/FS/IO/Internal.hs
@@ -11,6 +11,7 @@ module System.FS.IO.Internal (
   , read
   , sameError
   , seek
+  , tell
   , truncate
   , write
   ) where
@@ -64,6 +65,10 @@ write fh data' bytes = withOpenHandle "write" fh $ \h ->
 seek :: FHandle -> SeekMode -> Int64 -> IO ()
 seek fh seekMode size = void <$> withOpenHandle "seek" fh $ \h ->
   setFilePointerEx h size (fromSeekMode seekMode)
+
+-- | Request the absolute file offset stored in the handle
+tell :: FHandle -> IO Word64
+tell h = withOpenHandle "tell" h $ fmap fromIntegral . getCurrentFileOffset
 
 fromSeekMode :: SeekMode -> FilePtrDirection
 fromSeekMode AbsoluteSeek = fILE_BEGIN

--- a/fs-api/src/System/FS/API.hs
+++ b/fs-api/src/System/FS/API.hs
@@ -58,6 +58,16 @@ data HasFS m h = HasFS {
     -- and we don't want to emulate it's behaviour.
   , hSeek                    :: HasCallStack => Handle h -> SeekMode -> Int64 -> m ()
 
+    -- | Return the current absolute offset into the file
+    --
+    -- NOTE: may provide different answers on Windows than on Unix-based systems
+    -- in two cases, (1) when opening a existing file in append-only mode, or
+    -- (2) right after a file has been truncated. It seems that on Windows
+    -- systems, the offset is immediately up-to-date, whereas on Unix-based
+    -- systems the file offset may not be updated until you start writing >0
+    -- bytes to the file handle.
+  , hTell                    :: HasCallStack => Handle h -> m AbsOffset
+
     -- | Try to read @n@ bytes from a handle
     --
     -- When at the end of the file, an empty bytestring will be returned.

--- a/fs-api/src/System/FS/IO.hs
+++ b/fs-api/src/System/FS/IO.hs
@@ -50,6 +50,8 @@ ioHasFS mount = HasFS {
         F.truncate h sz
     , hGetSize = \(Handle h fp) -> liftIO $ rethrowFsError fp $
         F.getSize h
+    , hTell = \(Handle h fp) -> liftIO $ rethrowFsError fp $
+        AbsOffset <$> F.tell h
     , hPutSome = \(Handle h fp) bs -> liftIO $ rethrowFsError fp $ do
         BS.unsafeUseAsCStringLen bs $ \(ptr, len) ->
             fromIntegral <$> F.write h (castPtr ptr) (fromIntegral len)

--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Revision history for fs-sim
 
+## next release -- ????-??-??
+
+### Breaking
+
+* Add simulation implementations (`pureHasFS`, `simHasFS` and `mkSimErrorHasFS`)
+  for the new `hTell` function in the `HasFS` interface. The simulation has two
+  known limitations regarding `hTell` because of differing behaviour between
+  Windows and Unix-based systems.
+* Add an error stream to `Errors` for `hTell`.
+
+### Patch
+
+* `allNull` was not actually checking whether all streams in the argument
+  `Errors` are empty.
+* The `Show Errors` instance was not printing every stream.
+* The shrinker for `Errors` was not shrinking every stream.
+
 ## 0.2.1.1 -- 2023-10-30
 
 ### Patch

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -10,7 +10,7 @@ license-files:
 
 copyright:       2019-2023 Input Output Global Inc (IOG)
 author:          IOG Engineering Team
-maintainer:      operations@iohk.io, Joris Dral
+maintainer:      operations@iohk.io, Joris Dral (joris@well-typed.com)
 category:        Testing
 build-type:      Simple
 extra-doc-files: CHANGELOG.md

--- a/fs-sim/src/System/FS/Sim/Pure.hs
+++ b/fs-sim/src/System/FS/Sim/Pure.hs
@@ -29,6 +29,7 @@ pureHasFS = HasFS {
     , hClose                   = Mock.hClose
     , hIsOpen                  = Mock.hIsOpen
     , hSeek                    = Mock.hSeek
+    , hTell                    = Mock.hTell
     , hGetSome                 = Mock.hGetSome
     , hGetSomeAt               = Mock.hGetSomeAt
     , hPutSome                 = Mock.hPutSome

--- a/fs-sim/src/System/FS/Sim/STM.hs
+++ b/fs-sim/src/System/FS/Sim/STM.hs
@@ -50,6 +50,7 @@ simHasFS var = HasFS {
     , hClose                   = sim  .  Mock.hClose
     , hIsOpen                  = sim  .  Mock.hIsOpen
     , hSeek                    = sim ..: Mock.hSeek
+    , hTell                    = sim  .  Mock.hTell
     , hGetSome                 = sim  .: Mock.hGetSome
     , hGetSomeAt               = sim ..: Mock.hGetSomeAt
     , hPutSome                 = sim  .: Mock.hPutSome


### PR DESCRIPTION
`hTell` has two known limitations that are elaborated on in its haddock comment.

Alternative: instead of adding a new `hTell` primitive to `HasFS`, we can also change `hSeek` to return the file offset and implement `hTell` in terms of `hSeek`. This is something I might try still