### PR TITLE
Renaming of partial read/write and corruption functions

### DIFF
--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Orphan `Show` instance for `Foreign.C.Error.Errno` removed by `fs-api`.
 * New `primitive ^>=0.9` dependency
 * New `safe-wild-cards^>=1.0`dependency
+* Rename some functions related to partial reads/writes and corruption in `System.FS.Sim.Error`:
+  * Replace `hGetSomePartial` by `partialiseByteCount`/`partialiseWord64`.
+  * Replace `hPutSomePartial` by `partialiseByteString`
+  * Replace `corrupt` by `corruptByteString`
 
 ### Patch
 


### PR DESCRIPTION
I've given some thought to whether I should have added `DEPRECATED` pragmas for the old functions, but I concluded that it would probably be better to just remove them. `ouroboros-consensus` and `lsm-tree` are the only consumers of this package for now