### PR TITLE
Move Utils modules into the System.FS hierarchy

### DIFF
--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Remove orphan `Show` instance for `Foreign.C.Error.Errno`.
 * Provide implementations for the new primitives in the `IO` implementation of
   `HasFS`. As a result, `ioHasFS` now requires that `PrimState IO ~ PrimState m`.
+* Rename `Util.CallStack` and `Util.Condense` to `System.FS.CallStack` and
+  `System.FS.Condense` respectively.
 
 ### Non-breaking
 

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -31,12 +31,12 @@ library
     System.FS.API.Lazy
     System.FS.API.Strict
     System.FS.API.Types
+    System.FS.CallStack
+    System.FS.Condense
     System.FS.CRC
     System.FS.IO
     System.FS.IO.Internal
     System.FS.IO.Internal.Handle
-    Util.CallStack
-    Util.Condense
 
   default-language: Haskell2010
   build-depends:

--- a/fs-api/src/System/FS/API.hs
+++ b/fs-api/src/System/FS/API.hs
@@ -37,8 +37,7 @@ import           Data.Word
 import           System.Posix.Types (ByteCount)
 
 import           System.FS.API.Types as Types
-
-import           Util.CallStack
+import           System.FS.CallStack
 
 {------------------------------------------------------------------------------
   Record that abstracts over the filesystem

--- a/fs-api/src/System/FS/API/Lazy.hs
+++ b/fs-api/src/System/FS/API/Lazy.hs
@@ -22,7 +22,7 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.Word (Word64)
 import           System.FS.API as API
 import           System.FS.API.Strict
-import           Util.CallStack (HasCallStack, prettyCallStack)
+import           System.FS.CallStack (HasCallStack, prettyCallStack)
 
 -- | Makes sure it reads all requested bytes.
 -- If eof is found before all bytes are read, it throws an exception.

--- a/fs-api/src/System/FS/API/Strict.hs
+++ b/fs-api/src/System/FS/API/Strict.hs
@@ -11,7 +11,7 @@ module System.FS.API.Strict (
 import qualified Data.ByteString as BS
 import           Data.Word
 import           System.FS.API as API
-import           Util.CallStack
+import           System.FS.CallStack
 
 -- | This function makes sure that the whole 'BS.ByteString' is written.
 hPutAllStrict :: forall m h

--- a/fs-api/src/System/FS/API/Types.hs
+++ b/fs-api/src/System/FS/API/Types.hs
@@ -61,8 +61,8 @@ import           System.FilePath
 import           System.IO (SeekMode (..))
 import qualified System.IO.Error as IO
 
-import           Util.CallStack
-import           Util.Condense
+import           System.FS.CallStack
+import           System.FS.Condense
 
 {-------------------------------------------------------------------------------
   Modes

--- a/fs-api/src/System/FS/CallStack.hs
+++ b/fs-api/src/System/FS/CallStack.hs
@@ -3,7 +3,7 @@
 -- | CallStack with a nicer 'Show' instance
 --
 -- Use of this module is intended to /replace/ import of @GHC.Stack@
-module Util.CallStack (
+module System.FS.CallStack (
     prettyCallStack
     -- * opaque
   , PrettyCallStack

--- a/fs-api/src/System/FS/Condense.hs
+++ b/fs-api/src/System/FS/Condense.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Condensed but human-readable output (like 'Show').
-module Util.Condense (
+module System.FS.Condense (
     Condense (..)
   , Condense1 (..)
   , condense1

--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -32,6 +32,7 @@
   `Errors` are empty.
 * The `Show Errors` instance was not printing every stream.
 * The shrinker for `Errors` was not shrinking every stream.
+* Adapt to moving of `Util` modules in `fs-api`.
 
 ## 0.2.1.1 -- 2023-10-30
 

--- a/fs-sim/src/System/FS/Sim/Error.hs
+++ b/fs-sim/src/System/FS/Sim/Error.hs
@@ -64,9 +64,8 @@ import qualified Test.QuickCheck as QC
 import           Test.QuickCheck (ASCIIString (..), Arbitrary (..), Gen,
                      suchThat)
 
-import           Util.CallStack
-
 import           System.FS.API
+import           System.FS.CallStack
 
 import qualified System.FS.Sim.MockFS as MockFS
 import           System.FS.Sim.MockFS (HandleMock, MockFS)

--- a/fs-sim/src/System/FS/Sim/MockFS.hs
+++ b/fs-sim/src/System/FS/Sim/MockFS.hs
@@ -87,7 +87,7 @@ import           System.Posix.Types (ByteCount)
 
 import           System.FS.API (BufferOffset (..))
 import           System.FS.API.Types
-import           Util.CallStack
+import           System.FS.CallStack
 
 import qualified System.FS.Sim.FsTree as FS
 import           System.FS.Sim.FsTree (FsTree (..), FsTreeError (..))

--- a/fs-sim/test/Test/System/FS/StateMachine.hs
+++ b/fs-sim/test/Test/System/FS/StateMachine.hs
@@ -103,11 +103,10 @@ import           Test.Tasty (TestTree, localOption, testGroup)
 import           Test.Tasty.QuickCheck
 
 import           System.FS.API
+import           System.FS.CallStack
+import           System.FS.Condense
 import           System.FS.IO
 import qualified System.FS.IO.Internal as F
-
-import           Util.CallStack
-import           Util.Condense
 
 import           System.FS.Sim.FsTree (FsTree (..))
 import qualified System.FS.Sim.MockFS as Mock


### PR DESCRIPTION
It's not very nice that we have a `Util` hierarchy as part of a package, so I moved them to live in `System.FS` instead, which we are the only users of AFAIK