### PR TITLE
Combinators for `FsPath`s and file extensions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,6 +24,9 @@ tests: True
 test-show-details: direct
 benchmarks: True
 
+-- comment me if you are benchmarking
+import: cabal.project.debug
+
 if impl(ghc >=9.8)
   allow-newer:
     -- https://github.com/wrengr/unix-bytestring/pull/46

--- a/cabal.project.debug
+++ b/cabal.project.debug
@@ -1,0 +1,20 @@
+package fs-api
+  ghc-options: -fno-ignore-asserts
+
+package fs-sim
+  ghc-options: -fno-ignore-asserts
+
+-- Enable -fcheck-prim-bounds
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/21054
+if impl(ghc >=9.4.6 && <9.5 || >=9.6.3)
+  package primitive
+    ghc-options: -fcheck-prim-bounds
+
+  package vector
+    ghc-options: -fcheck-prim-bounds
+
+  package fs-api
+    ghc-options: -fcheck-prim-bounds
+
+  package fs-sim
+    ghc-options: -fcheck-prim-bounds

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -25,6 +25,13 @@
   `hGetBufExactly`, `hGetBufExactlyAt`, `hPutBufExactly`,  and
   `hPutBufExactlyAt`.
 * `NFData` instances for `FsPath`, `HasFS` and `Handle`.
+* Add 'FsPath' combinators: `(<.>)` and `addExtension`, `(</>)` and `combine.
+
+### Patch
+
+* Add a clarification in the documentation of `fsPathFromList` that each path
+  component should be non-empty, because directories/files with empty names are
+  not valid! Also, add an `assert`ion to `fsPathFromList` for this precondition.
 
 ## 0.2.0.1 -- 2023-10-30
 

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -73,16 +73,21 @@ test-suite fs-api-test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Main.hs
-  other-modules:    Test.System.FS.IO
+  other-modules:
+    Test.System.FS.API.FsPath
+    Test.System.FS.IO
+
   default-language: Haskell2010
   build-depends:
     , base
     , bytestring
+    , filepath
     , fs-api
     , primitive
     , tasty
     , tasty-quickcheck
     , temporary
+    , text
 
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns

--- a/fs-api/test/Main.hs
+++ b/fs-api/test/Main.hs
@@ -1,9 +1,11 @@
 module Main (main) where
 
-import           Test.System.FS.IO
+import qualified Test.System.FS.API.FsPath
+import qualified Test.System.FS.IO
 import           Test.Tasty
 
 main :: IO ()
 main = defaultMain $ testGroup "fs-api-test" [
-      Test.System.FS.IO.tests
+      Test.System.FS.API.FsPath.tests
+    , Test.System.FS.IO.tests
     ]

--- a/fs-api/test/Test/System/FS/API/FsPath.hs
+++ b/fs-api/test/Test/System/FS/API/FsPath.hs
@@ -1,0 +1,76 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.System.FS.API.FsPath (tests) where
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Prelude hiding (read)
+import qualified System.FilePath as FilePath
+import qualified System.FS.API as FS
+import           Test.Tasty
+import qualified Test.Tasty.QuickCheck as QC
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.System.FS.API.FsPath" [
+      testProperty "prop_combineCommutes" prop_combineCommutes
+    , testProperty "prop_addExtensionCommutes" prop_addExtensionCommutes
+    ]
+
+-- | Orphan instance that generates a __non-empty__ text!
+instance Arbitrary Text where
+  arbitrary = Text.pack <$> (arbitrary `suchThat` (not . null))
+  shrink x = [Text.pack x'' | let x' = Text.unpack x, x'' <- shrink x']
+
+-- | Commutativity property for 'FS.</>' and 'FilePath.</>'.
+--
+-- TODO: commutativity might not be the right name for this type of property.
+--
+-- @
+--   \x y -> toFilePath (x </> y) == toFilePath x </> toFilePath y
+-- @
+--
+-- The first argument is used to create a mount point, which makes the property
+-- more useful because we are testing more cases. Also, for 'FS.fsToFilePath' to
+-- work, we need at least the empty mountpoint.
+prop_combineCommutes :: [Text] -> [Text] -> [Text] -> Property
+prop_combineCommutes mnt path1 path2 =
+      QC.classify (FilePath.isValid rhs) "Valid file path"
+    $    lhs === rhs
+    .&&. FilePath.makeValid lhs === FilePath.makeValid rhs
+  where
+    mnt' = filePathFromList mnt
+    mnt'' = FS.MountPoint mnt'
+    fsp = FS.fsPathFromList path1 FS.</> FS.fsPathFromList path2
+    lhs = FS.fsToFilePath mnt'' fsp
+    rhs = mnt' FilePath.</> filePathFromList path1 FilePath.</> filePathFromList path2
+
+-- | Commutativity property for 'FS.<.>' and 'FilePath.<.>'.
+--
+-- TODO: commutativity might not be the right name for this type of property.
+--
+-- @
+--   \path ext -> toFilePath (path <.> ext) == toFilePath path <.> ext
+-- @
+--
+-- The first argument is used to create a mount point, which makes the property
+-- more useful because we are testing more cases. Also, for 'FS.fsToFilePath' to
+-- work, we need at least the empty mountpoint.
+prop_addExtensionCommutes :: [Text] -> [Text] -> String -> Property
+prop_addExtensionCommutes mnt path ext =
+      QC.classify (FilePath.isValid rhs) "Valid file path"
+    $ QC.classify (case ext of '.':_ -> True; _ -> False)
+                  "Extension to add starts with an extension separator (.)"
+    $    lhs === rhs
+    .&&. FilePath.makeValid lhs === FilePath.makeValid rhs
+  where
+    mnt' = filePathFromList mnt
+    mnt'' = FS.MountPoint (filePathFromList mnt)
+    fsp = FS.fsPathFromList path FS.<.> ext
+    lhs = FS.fsToFilePath mnt'' fsp
+    rhs = mnt' FilePath.</> filePathFromList path FilePath.<.> ext
+
+-- | Build a 'FilePath' by 'FilePath.combine'ing the directory/file names.
+filePathFromList :: [Text] -> FilePath
+filePathFromList [] = []
+filePathFromList xs = foldr (\y ys -> Text.unpack y FilePath.</> ys) (Text.unpack (last xs)) (init xs)


### PR DESCRIPTION
Related: #65 

This PR includes combinators like `(</>)` for `FsPath`s, which are inspired by the combinators of the same name from the `filepath` package.

I have also created a new issue https://github.com/input-output-hk/fs-sim/issues/68 because the internal representation of `FsPath`s seems suboptimal: we often need to linearly traverse the representation when we modify paths.