### PR TITLE
Only generate valid names for `FsPath` tests

### DIFF
--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -29,9 +29,8 @@
 
 ### Patch
 
-* Add a clarification in the documentation of `fsPathFromList` that each path
-  component should be non-empty, because directories/files with empty names are
-  not valid! Also, add an `assert`ion to `fsPathFromList` for this precondition.
+* Add a clarification in the documentation of `FsPath` that the user is
+  responsible for picking sensible directory/file names.
 
 ## 0.2.0.1 -- 2023-10-30
 

--- a/fs-api/src/System/FS/API/Types.hs
+++ b/fs-api/src/System/FS/API/Types.hs
@@ -101,6 +101,26 @@ allowExisting openMode = case openMode of
 -------------------------------------------------------------------------------}
 
 -- | A relative path.
+--
+-- === Invariant
+--
+-- The user of this library is tasked with picking sensible names of
+-- directories/files on a path. Amongst others, the following should hold:
+--
+-- * Names are non-empty
+--
+-- * Names are monotonic, i.e., they are not equal to @..@
+--
+-- * Names should not contain path separators or drive letters
+--
+-- In particular, names that satisfy these invariants should result in an
+-- 'FsPath' that remains relative to the HasFS instance root. For example, an
+-- @'FsPath' ["/"]@ would try to access the root folder, which is most likely
+-- outside of the scope of the HasFS instance.
+--
+-- \"@..@\" should not be used because @fs-sim@ will not be able to follow these
+-- types of back-links. @fs-sim@ will interpret \"@..@\" as a directory name
+-- instead.
 newtype FsPath = UnsafeFsPath { fsPathToList :: [Strict.Text] }
   deriving (Eq, Ord, Generic)
   deriving newtype NFData
@@ -108,7 +128,7 @@ newtype FsPath = UnsafeFsPath { fsPathToList :: [Strict.Text] }
 -- | Create a path from a list of directory/file names. All of the names should
 -- be non-empty.
 fsPathFromList :: [Strict.Text] -> FsPath
-fsPathFromList xs = assert (not (any Strict.null xs)) $ UnsafeFsPath (force xs)
+fsPathFromList xs = UnsafeFsPath (force xs)
 
 instance Show FsPath where
   show = intercalate "/" . map Strict.unpack . fsPathToList


### PR DESCRIPTION
Resolves #71

The names for directories and files that we used in `FsPath` tests were too arbitrary.  The documentation of `FsPath` now describes a number of invariants that should ensure that `FsPath`s make sense. Currently, the user is responsible for ensuring that these invariants are satisfied. It might be nice to dynamically check these invariants instead, see #73