### PR TITLE
Release `fs-sim-0.3.0.1` and `fs-sim-0.3.0.1`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-08-26T00:00:00Z
+  , hackage.haskell.org 2024-10-02T00:00:00Z
 
 packages:
   fs-api

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for fs-api
 
+## 0.3.0.1 -- 2024-10-02
+
+### Patch
+
+* Support `io-classes-1.6` and `io-classes-1.7`. Older versions of `io-classes`
+  are no longer supported.
+
 ## 0.3.0.0 -- 2024-08-26
 
 ### Breaking

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            fs-api
-version:         0.3.0.0
+version:         0.3.0.1
 synopsis:        Abstract interface for the file system
 description:     Abstract interface for the file system.
 license:         Apache-2.0
@@ -48,7 +48,7 @@ library
     , digest           ^>=0.0
     , directory        ^>=1.3
     , filepath         ^>=1.4  || ^>=1.5
-    , io-classes       ^>=1.0  || ^>=1.1  || ^>=1.2  || ^>=1.3 || ^>=1.4 || ^>=1.5
+    , io-classes       ^>=1.6  || ^>=1.7
     , primitive        ^>=0.9
     , safe-wild-cards  ^>=1.0
     , text             ^>=1.2  || ^>=2.0  || ^>=2.1

--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for fs-sim
 
+## 0.3.0.1 -- 2024-10-02
+
+### Patch
+
+* Support `io-classes-1.6` and `io-classes-1.7`. In these versions, `strict-stm`
+  has become a public sub-library of `io-classes`. As a result, older versions
+  of `io-classes` are no longer supported, and we now depend on
+  `io-classes:strict-stm` instead of `strict-stm`.
+
 ## 0.3.0.0 -- 2024-08-26
 
 ### Breaking

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            fs-sim
-version:         0.3.0.0
+version:         0.3.0.1
 synopsis:        Simulated file systems
 description:     Simulated file systems.
 license:         Apache-2.0
@@ -38,18 +38,18 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base               >=4.14  && <4.21
-    , base16-bytestring  ^>=0.1  || ^>=1.0
-    , bytestring         ^>=0.10 || ^>=0.11 || ^>=0.12
-    , containers         ^>=0.5  || ^>=0.6  || ^>=0.7
-    , fs-api             ^>=0.3
-    , io-classes         ^>=1.0  || ^>=1.1  || ^>=1.2  || ^>=1.3 || ^>=1.4 || ^>=1.5
-    , mtl                ^>=2.2  || ^>=2.3
-    , primitive          ^>=0.9
-    , QuickCheck         ^>=2.13 || ^>=2.14 || ^>=2.15
-    , safe-wild-cards    ^>=1.0
-    , strict-stm         ^>=1.0  || ^>=1.1  || ^>=1.2  || ^>=1.3 || ^>=1.4 || ^>=1.5
-    , text               ^>=1.2  || ^>=2.0  || ^>=2.1
+    , base                   >=4.14  && <4.21
+    , base16-bytestring      ^>=0.1  || ^>=1.0
+    , bytestring             ^>=0.10 || ^>=0.11 || ^>=0.12
+    , containers             ^>=0.5  || ^>=0.6  || ^>=0.7
+    , fs-api                 ^>=0.3
+    , io-classes             ^>=1.6  || ^>=1.7
+    , io-classes:strict-stm
+    , mtl                    ^>=2.2  || ^>=2.3
+    , primitive              ^>=0.9
+    , QuickCheck             ^>=2.13 || ^>=2.14 || ^>=2.15
+    , safe-wild-cards        ^>=1.0
+    , text                   ^>=1.2  || ^>=2.0  || ^>=2.1
 
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns
@@ -77,12 +77,12 @@ test-suite fs-sim-test
     , fs-api
     , fs-sim
     , generics-sop
+    , io-classes:strict-stm
     , pretty-show
     , primitive
     , QuickCheck
     , quickcheck-state-machine  >=0.10
     , random
-    , strict-stm
     , tasty
     , tasty-hunit
     , tasty-quickcheck


### PR DESCRIPTION
These are small patches to support `io-classes-1.6` and `io-classes-1.7`.