### PR TITLE
Expose `openHandles`

### DIFF
--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for fs-sim
 
+## Next version -- ????-??-??
+
+### Non-breaking
+
+* Expose `openHandles` for testing.
+
 ## 0.3.0.1 -- 2024-10-02
 
 ### Patch

--- a/fs-sim/src/System/FS/Sim/MockFS.hs
+++ b/fs-sim/src/System/FS/Sim/MockFS.hs
@@ -22,6 +22,7 @@ module System.FS.Sim.MockFS (
   , example
   , handleIsOpen
   , numOpenHandles
+  , openHandles
   , pretty
     -- * Debugging
   , dumpState


### PR DESCRIPTION
Exposing this function is useful to check not only that there are open handles but also what are those handles filepaths.