### PR TITLE
Make the `Condense SeekMode` instance a non-orphan instance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-12-09T15:45:06Z
+  , hackage.haskell.org 2024-12-30T06:24:32Z
 
 packages:
   fs-api

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision history for fs-api
 
+## ?.?.?.? -- ????-??-??
+
+### Non-breaking
+
+* Make the orphan `Condense` instance for `System.IO.SeekMode` into a non-orphan
+  instance. The instance is still exported from the same modules it was exported
+  from previously, `System.FS.API.Types` in particular.
+
 ## 0.3.0.1 -- 2024-10-02
 
 ### Patch

--- a/fs-api/src/System/FS/API/Types.hs
+++ b/fs-api/src/System/FS/API/Types.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
--- For Show Errno and Condense SeekMode instances
-{-# OPTIONS_GHC -Wno-orphans #-}
 module System.FS.API.Types (
     -- * Modes
     AllowExisting (..)
@@ -451,11 +449,6 @@ ioToFsErrorType ioErr = case Errno <$> GHC.ioe_errno ioErr of
 {-------------------------------------------------------------------------------
   Condense instances
 -------------------------------------------------------------------------------}
-
-instance Condense SeekMode where
-  condense RelativeSeek = "r"
-  condense AbsoluteSeek = "a"
-  condense SeekFromEnd  = "e"
 
 instance Condense AllowExisting where
   condense AllowExisting = ""

--- a/fs-api/src/System/FS/Condense.hs
+++ b/fs-api/src/System/FS/Condense.hs
@@ -23,6 +23,7 @@ import           Data.Text (Text, unpack)
 import           Data.Void
 import           Data.Word
 import           Numeric.Natural
+import           System.IO (SeekMode (..))
 import           Text.Printf (printf)
 
 {-------------------------------------------------------------------------------
@@ -111,3 +112,8 @@ instance Condense BS.Strict.ByteString where
 
 instance Condense BS.Lazy.ByteString where
   condense bs = show bs ++ "<" ++ show (BS.Lazy.length bs) ++ "b>"
+
+instance Condense SeekMode where
+  condense RelativeSeek = "r"
+  condense AbsoluteSeek = "a"
+  condense SeekFromEnd  = "e"


### PR DESCRIPTION
Also: update the index-state, because some new package versions were released for `bytestring`, `text` and `unix`