### PR TITLE
Bugfix for `hGetBufExactly` and `hGetBufExactlyAt`

### DIFF
--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -19,6 +19,9 @@
   This was already the semantics when using `hOpen` from the `ioHasFS` instance,
   but it was not reflected in the `allowExisting` function. `allowExisting
   Readmode` now returns `MustExist` instead of `AllowExisting`.
+* Bugfix: `hGetBufExactly` and `hGetBufExactlyAt` would previously try to read
+  too many bytes in the presence of partial reads. These functions now properly
+  count the number of remaining bytes that have to be read.
 
 ## 0.3.0.1 -- 2024-10-02
 

--- a/fs-api/src/System/FS/API.hs
+++ b/fs-api/src/System/FS/API.hs
@@ -263,7 +263,7 @@ hGetBufExactly hfs h buf bufOff c = go c bufOff
     go !remainingCount !currentBufOff
       | remainingCount == 0 = pure c
       | otherwise            = do
-          readBytes <- hGetBufSome hfs h buf currentBufOff c
+          readBytes <- hGetBufSome hfs h buf currentBufOff remainingCount
           if readBytes == 0 then
             throwIO FsError {
                 fsErrorType   = FsReachedEOF
@@ -294,7 +294,7 @@ hGetBufExactlyAt hfs h buf bufOff c off = go c off bufOff
     go !remainingCount !currentOffset !currentBufOff
       | remainingCount == 0 = pure c
       | otherwise            = do
-          readBytes <- hGetBufSomeAt hfs h buf currentBufOff c currentOffset
+          readBytes <- hGetBufSomeAt hfs h buf currentBufOff remainingCount currentOffset
           if readBytes == 0 then
             throwIO FsError {
                 fsErrorType   = FsReachedEOF


### PR DESCRIPTION
In the presence of partial reads, these functions would try to read more bytes than requested.