### PR TITLE
Allow using io-classes 1.8

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.4.8", "9.6.6", "9.8.4", "9.10.1", "9.12.1"]
+        ghc: ["9.4.8", "9.6.7", "9.8.4", "9.10.2", "9.12.2"]
         cabal: ["3.14.1.1"]
-        os: [ubuntu-latest, windows-latest, macOS-13]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         no-debug: [""]
         include:
-          - ghc: "9.6.6"
+          - ghc: "9.6.7"
             cabal: "3.12.1.0"
             os: ubuntu-latest
             no-debug: "no-debug"
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.6"]
+        ghc: ["9.6.7"]
         cabal: ["3.12.1.0"]
         os: [ubuntu-latest]
 
@@ -128,7 +128,7 @@ jobs:
     # an argument to cabal install. This ensures that we never rebuild
     # dependencies because of newly uploaded packages unless we want to.
     env:
-      hackage-index-state: "2024-04-10T14:36:07Z"
+      hackage-index-state: "2025-05-26T13:28:18Z"
 
     steps:
     - name: Checkout repository
@@ -183,14 +183,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.6"]
+        ghc: ["9.6.7"]
         cabal: ["3.12.1.0"]
         os: [ubuntu-latest]
 
     # See the comment on the hackage-index-state environment variable for the
     # stylish-haskell job.
     env:
-      hackage-index-state: "2024-04-10T14:36:07Z"
+      hackage-index-state: "2025-05-26T13:28:18Z"
 
     steps:
     - name: Checkout repository
@@ -245,7 +245,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.6"]
+        ghc: ["9.6.7"]
         cabal: ["3.10.3.0"]
         os: [ubuntu-latest]
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2025-02-11T00:00:00Z
+  , hackage.haskell.org 2025-05-26T13:28:18Z
 
 packages:
   fs-api

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Bugfix: `hGetBufExactly` and `hGetBufExactlyAt` would previously try to read
   too many bytes in the presence of partial reads. These functions now properly
   count the number of remaining bytes that have to be read.
+* Support `io-classes-1.8`
 
 ## 0.3.0.1 -- 2024-10-02
 

--- a/fs-api/CHANGELOG.md
+++ b/fs-api/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Patch
 
 * Make it build with `ghc-9.12`.
+* Drop support for `ghc-8.10` and `ghc-9.2`.
 * Bugfix: opening a file in read mode now expects the file to exist already.
   This was already the semantics when using `hOpen` from the `ioHasFS` instance,
   but it was not reflected in the `allowExisting` function. `allowExisting

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -48,7 +48,7 @@ library
     , digest           ^>=0.0
     , directory        ^>=1.3
     , filepath         ^>=1.4  || ^>=1.5
-    , io-classes       ^>=1.6  || ^>=1.7
+    , io-classes       ^>=1.6  || ^>=1.7  || ^>=1.8
     , primitive        ^>=0.9
     , safe-wild-cards  ^>=1.0
     , text             ^>=1.2  || ^>=2.0  || ^>=2.1

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -19,8 +19,7 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with:
-  GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
+tested-with:     GHC ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
 
 source-repository head
   type:     git

--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Patch
 
 * Make it build with `ghc-9.12`.
+* Drop support for `ghc-8.10` and `ghc-9.2`.
 * Support the new `MustExist` option for `AllowExisting` that was added in
   `fs-api`.
 

--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Patch
 
 * Make it build with `ghc-9.12`.
+* Support `io-classes-1.8`.
 * Drop support for `ghc-8.10` and `ghc-9.2`.
 * Support the new `MustExist` option for `AllowExisting` that was added in
   `fs-api`.

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -43,7 +43,7 @@ library
     , bytestring             ^>=0.10 || ^>=0.11 || ^>=0.12
     , containers             ^>=0.5  || ^>=0.6  || ^>=0.7
     , fs-api                 ^>=0.3
-    , io-classes             ^>=1.6  || ^>=1.7
+    , io-classes             ^>=1.6  || ^>=1.7  || ^>=1.8
     , io-classes:strict-stm
     , mtl                    ^>=2.2  || ^>=2.3
     , primitive              ^>=0.9

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -19,8 +19,7 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with:
-  GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
+tested-with:     GHC ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
 
 source-repository head
   type:     git


### PR DESCRIPTION
This PR allows using `io-classes-1.8`. We have to drop support for GHCs older than 9.4 as `io-classes-1.8` does not support them.