### PR TITLE
Re-enable support for GHC 9.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.4.8", "9.6.7", "9.8.4", "9.10.2", "9.12.2"]
+        ghc: ["9.2.8", "9.4.8", "9.6.7", "9.8.4", "9.10.2", "9.12.2"]
         cabal: ["3.14.1.1"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         no-debug: [""]

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2025-05-26T13:28:18Z
+  , hackage.haskell.org 2025-06-03T08:53:00Z
 
 packages:
   fs-api

--- a/fs-api/fs-api.cabal
+++ b/fs-api/fs-api.cabal
@@ -19,7 +19,7 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with:     GHC ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
+tested-with:     GHC ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
 
 source-repository head
   type:     git
@@ -41,14 +41,14 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base             >=4.14  && <4.22
+    , base             >=4.16  && <4.22
     , bytestring       ^>=0.10 || ^>=0.11 || ^>=0.12
     , containers       ^>=0.5  || ^>=0.6  || ^>=0.7
     , deepseq          ^>=1.4  || ^>=1.5
     , digest           ^>=0.0
     , directory        ^>=1.3
     , filepath         ^>=1.4  || ^>=1.5
-    , io-classes       ^>=1.6  || ^>=1.7  || ^>=1.8
+    , io-classes       ^>=1.6  || ^>=1.7  || ^>=1.8.0.1
     , primitive        ^>=0.9
     , safe-wild-cards  ^>=1.0
     , text             ^>=1.2  || ^>=2.0  || ^>=2.1

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -19,7 +19,7 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with:     GHC ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
+tested-with:     GHC ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
 
 source-repository head
   type:     git
@@ -38,12 +38,12 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base                   >=4.14  && <4.22
+    , base                   >=4.16  && <4.22
     , base16-bytestring      ^>=0.1  || ^>=1.0
     , bytestring             ^>=0.10 || ^>=0.11 || ^>=0.12
     , containers             ^>=0.5  || ^>=0.6  || ^>=0.7
     , fs-api                 ^>=0.3
-    , io-classes             ^>=1.6  || ^>=1.7  || ^>=1.8
+    , io-classes             ^>=1.6  || ^>=1.7  || ^>=1.8.0.1
     , io-classes:strict-stm
     , mtl                    ^>=2.2  || ^>=2.3
     , primitive              ^>=0.9


### PR DESCRIPTION
- tighten the lower bound on `base` to the version that comes with GHC 9.2
- tighten the constraint on `io-classes`
- re-enable GHC 9.2 in CI

Follow-up to https://github.com/input-output-hk/fs-sim/pull/101 (see [comment](https://github.com/input-output-hk/fs-sim/pull/101#pullrequestreview-2887617984))