### PR TITLE
Make `sim` operations exception safe by using `withMockFS`

### DIFF
--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for fs-sim
 
+## 0.4.1.1 -- 2026-04-10
+
+### Patch
+
+* Make `sim` operations exception safe by using `withMockFS`.
+
 ## 0.4.1.0 -- 2025-09-29
 
 ### Non-breaking

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: fs-sim
-version: 0.4.1.0
+version: 0.4.1.1
 synopsis: Simulated file systems
 description: Simulated file systems.
 license: Apache-2.0
@@ -19,7 +19,7 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with: ghc ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
+tested-with: ghc ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12 || ==9.14
 
 source-repository head
   type: git
@@ -30,7 +30,7 @@ source-repository this
   type: git
   location: https://github.com/input-output-hk/fs-sim
   subdir: fs-sim
-  tag: fs-sim-0.4.1.0
+  tag: fs-sim-0.4.1.1
 
 library
   hs-source-dirs: src

--- a/fs-sim/src/System/FS/Sim/Error.hs
+++ b/fs-sim/src/System/FS/Sim/Error.hs
@@ -559,7 +559,7 @@ instance Arbitrary Errors where
 
 -- | Alternative to 'simErrorHasFS' that creates 'TVar's internally.
 simErrorHasFS' ::
-  (MonadSTM m, MonadThrow m, PrimMonad m) =>
+  (MonadSTM m, MonadMask m, PrimMonad m) =>
   MockFS ->
   Errors ->
   m (HasFS m HandleMock)
@@ -569,7 +569,7 @@ simErrorHasFS' mockFS errs =
 -- | Introduce possibility of errors
 simErrorHasFS ::
   forall m.
-  (MonadSTM m, MonadThrow m, PrimMonad m) =>
+  (MonadSTM m, MonadMask m, PrimMonad m) =>
   StrictTMVar m MockFS ->
   StrictTVar m Errors ->
   HasFS m HandleMock
@@ -706,7 +706,7 @@ simErrorHasFS fsVar errorsVar =
 -- | Runs a computation provided an 'Errors' and an initial
 -- 'MockFS', producing a result and the final state of the filesystem.
 runSimErrorFS ::
-  (MonadSTM m, MonadThrow m, PrimMonad m) =>
+  (MonadSTM m, MonadMask m, PrimMonad m) =>
   MockFS ->
   Errors ->
   (StrictTVar m Errors -> HasFS m HandleMock -> m a) ->

--- a/fs-sim/src/System/FS/Sim/STM.hs
+++ b/fs-sim/src/System/FS/Sim/STM.hs
@@ -44,11 +44,9 @@ simHasFS' mockFS = simHasFS <$> newTMVarIO mockFS
 
 -- | Bracket-style helper that holds the MockFS lock for the duration of @f@.
 --
--- Acquire and release are wrapped in 'uninterruptibleMask' so that a
--- temporarily-empty TMVar (held by a concurrent 'sim' call) cannot cause a
--- masked cleanup to be interrupted while it waits for the lock. The body @f@
--- runs with the caller's original masking state restored, matching the
--- behaviour of 'Control.Concurrent.MVar.withMVar'.
+-- 'withMockFS' is not interruptible while waiting for the `MockFS` TMVar, but
+-- the body @f@ runs with the caller's original masking state restored, matching
+-- the behaviour of 'Control.Concurrent.MVar.withMVar'.
 withMockFS ::
   (MonadSTM m, MonadMask m) =>
   StrictTMVar m MockFS ->

--- a/fs-sim/src/System/FS/Sim/STM.hs
+++ b/fs-sim/src/System/FS/Sim/STM.hs
@@ -25,7 +25,7 @@ import System.FS.Sim.Prim
 --- result, the final state of the filesystem and a sequence of actions occurred
 --- in the filesystem.
 runSimFS ::
-  (MonadSTM m, MonadThrow m, PrimMonad m) =>
+  (MonadSTM m, MonadMask m, PrimMonad m) =>
   MockFS ->
   (HasFS m HandleMock -> m a) ->
   m (a, MockFS)
@@ -37,15 +37,35 @@ runSimFS fs act = do
 
 -- | Alternative to 'simHasFS' that creates 'TVar's internally.
 simHasFS' ::
-  (MonadSTM m, MonadThrow m, PrimMonad m) =>
+  (MonadSTM m, MonadMask m, PrimMonad m) =>
   MockFS ->
   m (HasFS m HandleMock)
 simHasFS' mockFS = simHasFS <$> newTMVarIO mockFS
 
+-- | Bracket-style helper that holds the MockFS lock for the duration of @f@.
+--
+-- Acquire and release are wrapped in 'uninterruptibleMask' so that a
+-- temporarily-empty TMVar (held by a concurrent 'sim' call) cannot cause a
+-- masked cleanup to be interrupted while it waits for the lock. The body @f@
+-- runs with the caller's original masking state restored, matching the
+-- behaviour of 'Control.Concurrent.MVar.withMVar'.
+withMockFS ::
+  (MonadSTM m, MonadMask m) =>
+  StrictTMVar m MockFS ->
+  (MockFS -> m (MockFS, Either FsError a)) ->
+  m a
+withMockFS var f = do
+  result <- uninterruptibleMask $ \restore -> do
+    st <- atomically $ takeTMVar var
+    (st', ea) <- restore (f st) `onException` atomically (putTMVar var st)
+    atomically $ putTMVar var st'
+    pure ea
+  either throwIO pure result
+
 -- | Equip @m@ with a @HasFs@ instance using the mock file system
 simHasFS ::
   forall m.
-  (MonadSTM m, MonadThrow m, PrimMonad m) =>
+  (MonadSTM m, MonadMask m, PrimMonad m) =>
   StrictTMVar m MockFS ->
   HasFS m HandleMock
 simHasFS var =
@@ -78,15 +98,10 @@ simHasFS var =
     }
  where
   sim :: FSSimT m a -> m a
-  sim m = do
-    st <- atomically $ takeTMVar var
+  sim m = withMockFS var $ \st ->
     runFSSimT m st >>= \case
-      Left e -> do
-        atomically $ putTMVar var st
-        throwIO e
-      Right (a, st') -> do
-        atomically $ putTMVar var st'
-        pure a
+      Left e -> pure (st, Left e)
+      Right (a, st') -> pure (st', Right a)
 
   (.:) :: (y -> z) -> (x0 -> x1 -> y) -> (x0 -> x1 -> z)
   (f .: g) x0 x1 = f (g x0 x1)


### PR DESCRIPTION
See https://github.com/IntersectMBO/ouroboros-consensus/issues/1294#issuecomment-4223745189 for a test-case that uncovered this issue.