### PR TITLE
Fixup 0.4.1.1 wrong version for 0.5.0.0

### DIFF
--- a/fs-sim/CHANGELOG.md
+++ b/fs-sim/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for fs-sim
 
-## 0.4.1.1 -- 2026-04-10
+## 0.5.0.0 -- 2026-04-23
 
-### Patch
+### Breaking
 
 * Make `sim` operations exception safe by using `withMockFS`.
+* Require `MonadMask` in `simHasFS`, `simHasFS'`, `runSimFS`.
 
 ## 0.4.1.0 -- 2025-09-29
 

--- a/fs-sim/fs-sim.cabal
+++ b/fs-sim/fs-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: fs-sim
-version: 0.4.1.1
+version: 0.5.0.0
 synopsis: Simulated file systems
 description: Simulated file systems.
 license: Apache-2.0
@@ -30,7 +30,7 @@ source-repository this
   type: git
   location: https://github.com/input-output-hk/fs-sim
   subdir: fs-sim
-  tag: fs-sim-0.4.1.1
+  tag: fs-sim-0.5.0.0
 
 library
   hs-source-dirs: src


### PR DESCRIPTION
I confused a breaking change with a patch one. Fixing up before releasing to CHaP